### PR TITLE
Creating a task definition for VEDA stac build

### DIFF
--- a/dags/example_dag.py
+++ b/dags/example_dag.py
@@ -1,7 +1,7 @@
-import pendulum
 import logging
 import time
 
+import pendulum
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
 from airflow.operators.python import PythonOperator

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -4,7 +4,7 @@ from airflow.operators.python import PythonOperator, BranchPythonOperator
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 from airflow_multi_dagrun.operators import TriggerMultiDagRunOperator
-
+import uuid
 from veda_data_pipeline.veda_pipeline_tasks.s3_discovery.handler import (
     s3_discovery_handler,
 )
@@ -45,7 +45,7 @@ def get_files_to_process(ti):
     dag_run_id = ti.dag_run.run_id
     for indx, payload_xcom in enumerate(payloads_xcom):
         time.sleep(2)
-        yield {"run_id": f"{dag_run_id}_{indx}", **payload, "payload": payload_xcom}
+        yield {"run_id": f"{dag_run_id}_{uuid.uuid4()}_{indx}", **payload, "payload": payload_xcom}
 
 
 def discover_choice(ti):

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -6,8 +6,9 @@ from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 from airflow_multi_dagrun.operators import TriggerMultiDagRunOperator
-from veda_data_pipeline.veda_pipeline_tasks.s3_discovery.handler import \
-    s3_discovery_handler
+from veda_data_pipeline.veda_pipeline_tasks.s3_discovery.handler import (
+    s3_discovery_handler,
+)
 
 group_kwgs = {"group_id": "Discover", "tooltip": "Discover"}
 

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -1,14 +1,13 @@
 import time
+import uuid
+
 from airflow.models.variable import Variable
-from airflow.operators.python import PythonOperator, BranchPythonOperator
+from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 from airflow_multi_dagrun.operators import TriggerMultiDagRunOperator
-import uuid
-from veda_data_pipeline.veda_pipeline_tasks.s3_discovery.handler import (
-    s3_discovery_handler,
-)
-
+from veda_data_pipeline.veda_pipeline_tasks.s3_discovery.handler import \
+    s3_discovery_handler
 
 group_kwgs = {"group_id": "Discover", "tooltip": "Discover"}
 
@@ -45,7 +44,11 @@ def get_files_to_process(ti):
     dag_run_id = ti.dag_run.run_id
     for indx, payload_xcom in enumerate(payloads_xcom):
         time.sleep(2)
-        yield {"run_id": f"{dag_run_id}_{uuid.uuid4()}_{indx}", **payload, "payload": payload_xcom}
+        yield {
+            "run_id": f"{dag_run_id}_{uuid.uuid4()}_{indx}",
+            **payload,
+            "payload": payload_xcom,
+        }
 
 
 def discover_choice(ti):

--- a/dags/veda_data_pipeline/groups/ecs_tasks.py
+++ b/dags/veda_data_pipeline/groups/ecs_tasks.py
@@ -8,7 +8,6 @@ from airflow.providers.amazon.aws.operators.ecs import (
 from airflow.hooks.base import BaseHook
 import json
 
-
 def get_aws_keys_from_connection(connection_id="aws_default"):
     conn = BaseHook.get_connection(connection_id)
     return {
@@ -37,7 +36,7 @@ def subdag_ecs_task(
     if environment_vars is None:
         environment_vars = list()
     with TaskGroup(**group_kwgs) as ecs_task_grp:
-        if stage == "dev":
+        if stage == "local":
             from airflow.providers.docker.operators.docker import DockerOperator
 
             return DockerOperator(

--- a/dags/veda_data_pipeline/groups/ecs_tasks.py
+++ b/dags/veda_data_pipeline/groups/ecs_tasks.py
@@ -1,12 +1,12 @@
+import json
+
+from airflow.hooks.base import BaseHook
+from airflow.providers.amazon.aws.operators.ecs import (
+    EcsDeregisterTaskDefinitionOperator, EcsRegisterTaskDefinitionOperator,
+    EcsRunTaskOperator)
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
-from airflow.providers.amazon.aws.operators.ecs import (
-    EcsDeregisterTaskDefinitionOperator,
-    EcsRegisterTaskDefinitionOperator,
-    EcsRunTaskOperator,
-)
-from airflow.hooks.base import BaseHook
-import json
+
 
 def get_aws_keys_from_connection(connection_id="aws_default"):
     conn = BaseHook.get_connection(connection_id)
@@ -37,7 +37,8 @@ def subdag_ecs_task(
         environment_vars = list()
     with TaskGroup(**group_kwgs) as ecs_task_grp:
         if stage == "local":
-            from airflow.providers.docker.operators.docker import DockerOperator
+            from airflow.providers.docker.operators.docker import \
+                DockerOperator
 
             return DockerOperator(
                 task_id=task_id,

--- a/dags/veda_data_pipeline/groups/ecs_tasks.py
+++ b/dags/veda_data_pipeline/groups/ecs_tasks.py
@@ -2,8 +2,10 @@ import json
 
 from airflow.hooks.base import BaseHook
 from airflow.providers.amazon.aws.operators.ecs import (
-    EcsDeregisterTaskDefinitionOperator, EcsRegisterTaskDefinitionOperator,
-    EcsRunTaskOperator)
+    EcsDeregisterTaskDefinitionOperator,
+    EcsRegisterTaskDefinitionOperator,
+    EcsRunTaskOperator,
+)
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -37,8 +39,7 @@ def subdag_ecs_task(
         environment_vars = list()
     with TaskGroup(**group_kwgs) as ecs_task_grp:
         if stage == "local":
-            from airflow.providers.docker.operators.docker import \
-                DockerOperator
+            from airflow.providers.docker.operators.docker import DockerOperator
 
             return DockerOperator(
                 task_id=task_id,

--- a/dags/veda_data_pipeline/groups/processing_group.py
+++ b/dags/veda_data_pipeline/groups/processing_group.py
@@ -1,16 +1,13 @@
 import json
 import logging
 
-from airflow.utils.task_group import TaskGroup
-from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
-
-
-from airflow.operators.python import PythonOperator, BranchPythonOperator
-from airflow.models.variable import Variable
 import smart_open
-
-from veda_data_pipeline.src.submit_stac import submission_handler
+from airflow.models.variable import Variable
+from airflow.operators.python import BranchPythonOperator, PythonOperator
+from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
+from airflow.utils.task_group import TaskGroup
 from veda_data_pipeline.src.cogify import cogify_handler
+from veda_data_pipeline.src.submit_stac import submission_handler
 
 group_kwgs = {"group_id": "Process", "tooltip": "Process"}
 

--- a/dags/veda_data_pipeline/groups/processing_group.py
+++ b/dags/veda_data_pipeline/groups/processing_group.py
@@ -1,19 +1,18 @@
 import json
 import logging
+
 from airflow.utils.task_group import TaskGroup
+from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
+
+
 from airflow.operators.python import PythonOperator, BranchPythonOperator
 from airflow.models.variable import Variable
 import smart_open
 
-from veda_data_pipeline.groups.ecs_tasks import subdag_ecs_task
-from veda_data_pipeline.veda_pipeline_tasks.submit_stac.handler import (
-    submission_handler,
-)
-from veda_data_pipeline.veda_pipeline_tasks.cogify.handler import cogify_handler
-
+from veda_data_pipeline.src.submit_stac import submission_handler
+from veda_data_pipeline.src.cogify import cogify_handler
 
 group_kwgs = {"group_id": "Process", "tooltip": "Process"}
-subgroup_kwgs = {"ecs_group_id": "ECSTasks", "subdag_ecs_task_id": "build_stac"}
 
 
 def log_task(text: str):
@@ -22,35 +21,19 @@ def log_task(text: str):
 
 def submit_to_stac_ingestor_task(ti):
     print("Submit STAC ingestor")
-    event = json.loads(
-        ti.xcom_pull(
-            task_ids=f"{group_kwgs['group_id']}.{subgroup_kwgs['ecs_group_id']}.{subgroup_kwgs['subdag_ecs_task_id']}"
-        )
-    )
-
+    event = json.loads(ti.xcom_pull(task_ids=f"{group_kwgs['group_id']}.build_stac"))
     success_file = event["payload"]["success_event_key"]
     with smart_open.open(success_file, "r") as _file:
         stac_items = json.loads(_file.read())
-    cognito_app_secret = Variable.get("COGNITO_APP_SECRET")
-    stac_ingestor_api_url = Variable.get("STAC_INGESTOR_API_URL")
+
     for item in stac_items:
-        submission_handler(
-            event={"stac_item": item, **event},
-            cognito_app_secret=cognito_app_secret,
-            stac_ingestor_api_url=stac_ingestor_api_url,
-        )
+        submission_handler(item)
     return event
 
 
 def cogify_task(ti):
     payload = ti.dag_run.conf
-    earthdata_username = None
-    earthdata_password = None
-    return cogify_handler(
-        file_uri=payload,
-        earthdata_username=earthdata_username,
-        earthdata_password=earthdata_password,
-    )
+    return cogify_handler(payload)
 
 
 def cogify_choice(ti, **kwargs):
@@ -59,47 +42,61 @@ def cogify_choice(ti, **kwargs):
     if payload["cogify"]:
         return f"{group_kwgs['group_id']}.cogify"
 
-    return f"{group_kwgs['group_id']}.{subgroup_kwgs['ecs_group_id']}.build_stac_task_register"
+    return f"{group_kwgs['group_id']}.build_stac"
 
 
 def subdag_process():
     with TaskGroup(**group_kwgs) as process_grp:
-        MWAA_STACK_CONF = Variable.get("MWAA_STACK_CONF", deserialize_json=True)
-        acct_id = MWAA_STACK_CONF.get("ACCOUNT_ID")
-        region = MWAA_STACK_CONF.get("AWS_REGION")
-        prefix = MWAA_STACK_CONF.get("PREFIX")
         cogify_branching = BranchPythonOperator(
             task_id="cogify_branching",
             trigger_rule="one_success",
             python_callable=cogify_choice,
         )
-        external_role_arn = Variable.get("ASSUME_ROLE_READ_ARN")
-        build_stac = subdag_ecs_task(
-            task_id=subgroup_kwgs["subdag_ecs_task_id"],
-            task_definition_family="ecs_veda_family",
-            cpu="1024",
-            memory="2048",
-            cmd='/usr/local/bin/python handler.py --payload "{}"'.format(
-                "{{ task_instance.dag_run.conf }}"
-            ),
-            container_name=f"{prefix}-veda-build_stac",
-            docker_image=f"{acct_id}.dkr.ecr.{region}.amazonaws.com/{prefix}-veda-build_stac",
-            mwaa_stack_conf=MWAA_STACK_CONF.copy(),
-            stage=MWAA_STACK_CONF.get("STAGE"),
-            environment_vars=[
-                {
-                    "name": "EXTERNAL_ROLE_ARN",
-                    "value": external_role_arn,
+        mwaa_stack_conf = Variable.get("MWAA_STACK_CONF", deserialize_json=True)
+        build_stac = EcsRunTaskOperator(
+            task_id="build_stac",
+            trigger_rule="none_failed",
+            cluster=f"{mwaa_stack_conf.get('PREFIX')}-cluster",
+            task_definition=f"{mwaa_stack_conf.get('PREFIX')}-tasks",
+            launch_type="FARGATE",
+            do_xcom_push=True,
+            overrides={
+                "containerOverrides": [
+                    {
+                        "name": f"{mwaa_stack_conf.get('PREFIX')}-veda-stac-build",
+                        "command": [
+                            "/usr/local/bin/python",
+                            "handler.py",
+                            "--payload",
+                            "{}".format("{{ task_instance.dag_run.conf }}"),
+                        ],
+                        "environment": [
+                            {
+                                "name": "EXTERNAL_ROLE_ARN",
+                                "value": Variable.get("ASSUME_ROLE_READ_ARN"),
+                            },
+                            {
+                                "name": "BUCKET",
+                                "value": "veda-data-pipelines-staging-lambda-ndjson-bucket",
+                            },
+                            {
+                                "name": "EVENT_BUCKET",
+                                "value": mwaa_stack_conf.get("EVENT_BUCKET"),
+                            },
+                        ],
+                        "memory": 2048,
+                        "cpu": 1024,
+                    },
+                ],
+            },
+            network_configuration={
+                "awsvpcConfiguration": {
+                    "securityGroups": mwaa_stack_conf.get("SECURITYGROUPS"),
+                    "subnets": mwaa_stack_conf.get("SUBNETS"),
                 },
-                {
-                    "name": "BUCKET",
-                    "value": "veda-data-pipelines-staging-lambda-ndjson-bucket",
-                },
-                {
-                    "name": "EVENT_BUCKET",
-                    "value": MWAA_STACK_CONF.get("EVENT_BUCKET"),
-                },
-            ],
+            },
+            awslogs_group=mwaa_stack_conf.get("LOG_GROUP_NAME"),
+            awslogs_stream_prefix=f"ecs/{mwaa_stack_conf.get('PREFIX')}-veda-stac-build",  # prefix with container name
         )
         cogify = PythonOperator(task_id="cogify", python_callable=cogify_task)
         submit_to_stac_ingestor = PythonOperator(

--- a/dags/veda_data_pipeline/src/cogify.py
+++ b/dags/veda_data_pipeline/src/cogify.py
@@ -1,16 +1,16 @@
-from affine import Affine
 import os
-import requests
-from botocore.exceptions import ClientError
+
 import boto3
-from netCDF4 import Dataset
 import numpy as np
+import requests
+from affine import Affine
+from botocore.exceptions import ClientError
+from netCDF4 import Dataset
 from rasterio.crs import CRS
 from rasterio.io import MemoryFile
 from rasterio.warp import calculate_default_transform
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
-
 
 config = {
     "DEFAULT": {"output_bucket": "climatedashboard-data", "output_dir": "OMDOAO3e_003"},

--- a/dags/veda_data_pipeline/src/submit_stac.py
+++ b/dags/veda_data_pipeline/src/submit_stac.py
@@ -1,16 +1,17 @@
-from dataclasses import dataclass
 import json
 import sys
+from dataclasses import dataclass
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict
+
 from typing import Any, Dict, Optional, Union
 
-from airflow.models.variable import Variable
 import boto3
 import requests
+from airflow.models.variable import Variable
 
 
 class InputBase(TypedDict):

--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -1,8 +1,7 @@
+import pendulum
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.trigger_rule import TriggerRule
-import pendulum
-
 from veda_data_pipeline.groups.discover_group import subdag_discover
 
 dag_doc_md = """

--- a/dags/veda_data_pipeline/veda_process_pipeline.py
+++ b/dags/veda_data_pipeline/veda_process_pipeline.py
@@ -29,14 +29,27 @@ This DAG is supposed to be triggered by `veda_discover`. But you still can trigg
 - [Supports linking to external content](https://github.com/NASA-IMPACT/veda-data-pipelines)
 """
 
+templat_dag_run_conf = {
+
+        "collection": "<collection_name>",
+        "prefix": "<prefix>/",
+        "bucket": "<bucket>",
+        "filename_regex": "<filename_regex>",
+        "discovery": "<s3>|cmr",
+        "datetime_range": "<month>|<day>",
+        "upload": "<false> | true",
+        "cogify": "false | true",
+        "payload": "<s3_uri_event_payload"
+    }
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
     "schedule_interval": None,
     "catchup": False,
     "doc_md": dag_doc_md,
+
 }
 
-with DAG("veda_ingest", **dag_args) as dag:
+with DAG("veda_ingest",params=templat_dag_run_conf, **dag_args) as dag:
     start = DummyOperator(task_id="Start", dag=dag)
     end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
 

--- a/dags/veda_data_pipeline/veda_process_pipeline.py
+++ b/dags/veda_data_pipeline/veda_process_pipeline.py
@@ -1,8 +1,7 @@
+import pendulum
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.trigger_rule import TriggerRule
-import pendulum
-
 from veda_data_pipeline.groups.processing_group import subdag_process
 
 dag_doc_md = """
@@ -30,26 +29,24 @@ This DAG is supposed to be triggered by `veda_discover`. But you still can trigg
 """
 
 templat_dag_run_conf = {
-
-        "collection": "<collection_name>",
-        "prefix": "<prefix>/",
-        "bucket": "<bucket>",
-        "filename_regex": "<filename_regex>",
-        "discovery": "<s3>|cmr",
-        "datetime_range": "<month>|<day>",
-        "upload": "<false> | true",
-        "cogify": "false | true",
-        "payload": "<s3_uri_event_payload"
-    }
+    "collection": "<collection_name>",
+    "prefix": "<prefix>/",
+    "bucket": "<bucket>",
+    "filename_regex": "<filename_regex>",
+    "discovery": "<s3>|cmr",
+    "datetime_range": "<month>|<day>",
+    "upload": "<false> | true",
+    "cogify": "false | true",
+    "payload": "<s3_uri_event_payload",
+}
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
     "schedule_interval": None,
     "catchup": False,
     "doc_md": dag_doc_md,
-
 }
 
-with DAG("veda_ingest",params=templat_dag_run_conf, **dag_args) as dag:
+with DAG("veda_ingest", params=templat_dag_run_conf, **dag_args) as dag:
     start = DummyOperator(task_id="Start", dag=dag)
     end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
 

--- a/docker_tasks/build_stac/handler.py
+++ b/docker_tasks/build_stac/handler.py
@@ -1,15 +1,16 @@
-from argparse import ArgumentParser
 import ast
-from contextlib import closing
 import json
-from multiprocessing import Pool, cpu_count
 import os
+from argparse import ArgumentParser
+from contextlib import closing
+from multiprocessing import Pool, cpu_count
+from time import sleep, time
 from typing import Any, Dict, TypedDict, Union
 from uuid import uuid4
-from time import time, sleep
-import smart_open
 
-from utils import stac as stac, events
+import smart_open
+from utils import events
+from utils import stac as stac
 
 
 class S3LinkOutput(TypedDict):

--- a/docker_tasks/build_stac/tests/conftest.py
+++ b/docker_tasks/build_stac/tests/conftest.py
@@ -1,11 +1,10 @@
 import os
 from unittest import mock
 
-import pytest
 import boto3
+import pytest
 from moto import mock_s3
-
-from mypy_boto3_s3.service_resource import S3ServiceResource, Bucket
+from mypy_boto3_s3.service_resource import Bucket, S3ServiceResource
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/docker_tasks/build_stac/tests/test_handler.py
+++ b/docker_tasks/build_stac/tests/test_handler.py
@@ -1,13 +1,12 @@
 import contextlib
 from typing import TYPE_CHECKING, Any, Dict, Type
 from unittest.mock import MagicMock, Mock
-from pydantic import ValidationError
-
-import pytest
-from pystac import Item
 
 import handler
-from utils import stac, events
+import pytest
+from pydantic import ValidationError
+from pystac import Item
+from utils import events, stac
 
 if TYPE_CHECKING:
     from functools import _SingleDispatchCallable

--- a/docker_tasks/build_stac/tests/test_regex.py
+++ b/docker_tasks/build_stac/tests/test_regex.py
@@ -1,7 +1,6 @@
-import pytest
-
 from datetime import datetime
 
+import pytest
 from utils import regex
 
 

--- a/docker_tasks/build_stac/utils/events.py
+++ b/docker_tasks/build_stac/utils/events.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 from typing import Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
 import pystac
-
+from pydantic import BaseModel, Field
 
 INTERVAL = Literal["month", "year", "day"]
 

--- a/docker_tasks/build_stac/utils/regex.py
+++ b/docker_tasks/build_stac/utils/regex.py
@@ -1,10 +1,10 @@
 import re
-from typing import Callable, Dict, Tuple, Union
 from datetime import datetime
+from typing import Callable, Dict, Tuple, Union
+
 from dateutil.relativedelta import relativedelta
 
 from . import events
-
 
 DATERANGE = Tuple[datetime, datetime]
 

--- a/docker_tasks/build_stac/utils/stac.py
+++ b/docker_tasks/build_stac/utils/stac.py
@@ -1,13 +1,15 @@
 import os
-from pathlib import Path
 from functools import singledispatch
+from pathlib import Path
+
 import pystac
 import rasterio
 from cmr import GranuleQuery
 from pystac.utils import str_to_datetime
-from rio_stac import stac
 from rasterio.session import AWSSession
-from . import regex, events, role
+from rio_stac import stac
+
+from . import events, regex, role
 
 
 def create_item(

--- a/infrastructure/task_definition.tf
+++ b/infrastructure/task_definition.tf
@@ -1,0 +1,27 @@
+resource "aws_ecs_task_definition" "veda_task_definition" {
+
+
+  container_definitions = jsonencode([
+
+    {
+      name      = "${var.prefix}-veda-stac-build"
+      image     = "${local.account_id}.dkr.ecr.${local.aws_region}.amazonaws.com/${var.prefix}-veda-build_stac"
+      essential = true,
+      logConfiguration = {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": module.mwaa.log_group_name,
+            "awslogs-region": local.aws_region,
+            "awslogs-stream-prefix": "ecs"
+          }
+      }
+    }
+  ])
+  family                   = "${var.prefix}-tasks"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 1024
+  memory                   = 2048
+  execution_role_arn = module.mwaa.mwaa_role_arn
+  task_role_arn = module.mwaa.mwaa_role_arn
+}

--- a/scripts/collection.py
+++ b/scripts/collection.py
@@ -1,11 +1,9 @@
 import os
 import sys
 
-from pypgstac.load import Loader, Methods
 from pypgstac.db import PgstacDB
-
-from utils import data_files, DATA_PATH, get_secret
-
+from pypgstac.load import Loader, Methods
+from utils import DATA_PATH, data_files, get_secret
 
 collections_path = os.path.join(DATA_PATH, "collections")
 

--- a/scripts/item.py
+++ b/scripts/item.py
@@ -5,8 +5,7 @@ import sys
 
 import boto3
 import requests
-
-from utils import data_files, DATA_PATH, MWAA_NAME
+from utils import DATA_PATH, MWAA_NAME, data_files
 
 dag_name = "veda_discover"
 airflow_client = boto3.client("mwaa")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,7 +1,7 @@
 import base64
-import json
 import functools
 import glob
+import json
 import os
 from sys import argv
 


### PR DESCRIPTION
**Summary:** Summary of changes

Previously we were doing register the task then run `build stac` then de-register the task but it turns out it added so much overhead. This implementation will use one AWS task definition to run `build stac` 

## Changes

* Removing register task from processing dag
* Adding an AWS task definition for `build stac` task
* Adding random uuid to run DAG (in case we want to re-run a successful task) 

## PR Checklist

- [x] PR comment added
