### PR TITLE
Remove direct connection to DB in collection ingest

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed 
+
+- Insert collections via ingestor API rather than directly with pgstac ([#13](https://github.com/NASA-IMPACT/veda-data-airflow/pull/13))

--- a/scripts/collection.py
+++ b/scripts/collection.py
@@ -1,55 +1,63 @@
+import json
 import os
 import sys
 
+import requests
+
 from pypgstac.db import PgstacDB
 from pypgstac.load import Loader, Methods
-from utils import DATA_PATH, data_files, get_secret
-
-collections_path = os.path.join(DATA_PATH, "collections")
+from utils import get_collections, get_secret
 
 
-def get_dsn_string(secret: dict, localhost: bool = False) -> str:
-    """Form database connection string from a dictionary of connection secrets
-
-    Args:
-        secret (dict): dictionary containing connection secrets including username, database name, host, and password
-
-    Returns:
-        dsn (str): full database data source name
-    """
-    if localhost:
-        host = "localhost"
-        port = 9999
-    else:
-        host = secret["host"]
-        port = secret["port"]
-
-    return f"postgres://{secret['username']}:{secret['password']}@{host}:{port}/{secret.get('dbname', 'postgis')}"
-
-
-def insert_collection(collection_ndjson):
-    secret_name = os.environ.get("SECRET_NAME")
-    con_secrets = get_secret(secret_name)
-    dsn = get_dsn_string(con_secrets)
-
-    with PgstacDB(dsn=dsn, debug=False) as db:
-        loader = Loader(db=db)
-        loader.load_collections(collection_ndjson, Methods.upsert)
+def get_app_credentials(
+    cognito_domain: str, client_id: str, client_secret: str, scope: str, **kwargs
+):
+    response = requests.post(
+        f"{cognito_domain}/oauth2/token",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        auth=(client_id, client_secret),
+        data={
+            "grant_type": "client_credentials",
+            # A space-separated list of scopes to request for the generated access token.
+            "scope": scope,
+        },
+    )
+    try:
+        response.raise_for_status()
+    except:
+        print(response.text)
+        raise
+    return response.json()
 
 
 def insert_collections(files):
+    print("Authenticating")
+    cognito_details = get_secret(os.environ.get("COGNITO_APP_SECRET"))
+    credentials = get_app_credentials(**cognito_details)
+    bearer_token = credentials["access_token"]
+
     print("Inserting collections:")
-    for file in files:
-        print(file)
-        try:
-            insert_collection(file)
-            print("Inserted")
-        except Exception as ex:
-            print(f"Error inserting collection. {ex}")
-            raise
+    base_url = os.environ.get("STAC_INGESTOR_API_URL")
+    with requests.Session() as s:
+        for file in files:
+            print(file)
+            try:
+                with open(file) as fd:
+                    response = s.post(
+                        f"{base_url.rstrip('/')}/collections",
+                        json=json.load(fd),
+                        headers={"Authorization": f"Bearer {bearer_token}"},
+                    )
+                    response.raise_for_status()
+                    print(response.text)
+            except:
+                print("Error inserting collection.")
+                raise
 
 
 if __name__ == "__main__":
     collection_regex = sys.argv[1]
-    files = data_files(collection_regex, collections_path)
+    files = get_collections(collection_regex)
     insert_collections(files)

--- a/scripts/collection.py
+++ b/scripts/collection.py
@@ -4,8 +4,6 @@ import sys
 
 import requests
 
-from pypgstac.db import PgstacDB
-from pypgstac.load import Loader, Methods
 from utils import get_collections, get_secret
 
 
@@ -26,7 +24,7 @@ def get_app_credentials(
     )
     try:
         response.raise_for_status()
-    except:
+    except Exception:
         print(response.text)
         raise
     return response.json()
@@ -52,7 +50,7 @@ def insert_collections(files):
                     )
                     response.raise_for_status()
                     print(response.text)
-            except:
+            except Exception:
                 print("Error inserting collection.")
                 raise
 

--- a/scripts/collection.sh
+++ b/scripts/collection.sh
@@ -9,7 +9,7 @@ then
   set -a; source $DOT_ENV; set +a
   shift
 else
-  echo "Run: ./scripts/item.sh <.env_file>"
+  echo "Run: ./scripts/collection.sh <.env_file>"
   echo "Please create $DOT_ENV file first and try again"
   exit 1
 fi

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -25,11 +25,22 @@ def arguments():
         return
     return argv[1:]
 
+DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "data")
 
 def data_files(data, data_path):
     files = []
     files.extend(glob.glob(os.path.join(data_path, f"{data}*.json")))
     return files
+
+
+def get_items(query):
+    items_path = os.path.join(DATA_PATH, "step_function_inputs")
+    return data_files(query, items_path)
+
+
+def get_collections(query):
+    collections_path = os.path.join(DATA_PATH, "collections")
+    return data_files(query, collections_path)
 
 
 def args_handler(func):
@@ -68,3 +79,8 @@ def get_secret(secret_name: str) -> None:
         return json.loads(get_secret_value_response["SecretString"])
     else:
         return json.loads(base64.b64decode(get_secret_value_response["SecretBinary"]))
+
+
+def get_mwaa_cli_token():
+    airflow_client = boto3.client("mwaa")
+    return airflow_client.create_cli_token(Name=MWAA_NAME)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -25,7 +25,9 @@ def arguments():
         return
     return argv[1:]
 
+
 DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "data")
+
 
 def data_files(data, data_path):
     files = []


### PR DESCRIPTION
**Summary:**
Removes direct connection to PGStac DB in favor of submission of collection to the Ingestor API.

```bash
./scripts/collection.sh .env IS2SITMOGR4-cog
Authenticating
Inserting collections:
/Users/npzimmerman/git_repos/nasa-impact/veda-data-airflow/scripts/../data/collections/IS2SITMOGR4-cog.json
["Successfully published: IS2SITMOGR4-cog"]
```

(A port of relevant changes from https://github.com/NASA-IMPACT/veda-data-pipelines/pull/304)

Addresses [VEDA-XX: Develop amazing new feature](https://github.com/NASA-IMPACT/veda-data-pipelines/issues/XX)

## Changes

* Use HTTP submission to the stac ingestor in place of directly leveraging PGStac
* Added a changelog

## PR Checklist

- [x] Update CHANGELOG
- [x] Ad-hoc testing - Deploy changes and test manually