### PR TITLE
Bug fix: Workflow fails when `vector` or `cogify` isn't present in the payload

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed 
 
 - Insert collections via ingestor API rather than directly with pgstac ([#13](https://github.com/NASA-IMPACT/veda-data-airflow/pull/13))
+- The `vector` and `cogify` fields are now optional in the payload

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -55,7 +55,7 @@ def get_files_to_process(ti):
 def vector_raster_choice(ti):
     payload = ti.dag_run.conf
 
-    if payload["vector"]:
+    if payload.get("vector"):
         return f"{group_kwgs['group_id']}.parallel_run_process_vectors"
     return f"{group_kwgs['group_id']}.parallel_run_process_rasters"
 

--- a/dags/veda_data_pipeline/groups/processing_group.py
+++ b/dags/veda_data_pipeline/groups/processing_group.py
@@ -45,7 +45,7 @@ def cogify_task(ti):
 def cogify_choice(ti, **kwargs):
     # Only get the payload from the successful task
     payload = ti.dag_run.conf
-    if payload["cogify"]:
+    if payload.get("cogify"):
         return f"{group_kwgs['group_id']}.cogify"
 
     return f"{group_kwgs['group_id']}.build_stac"


### PR DESCRIPTION
**Summary:** When `vector` or `cogify` isn't specified in the payload, the airflow run fails. This isn't expected behavior since these values should be optional.

## Changes

* Makes the "vector" and "cogify" fields in the payload optional

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests