### PR TITLE
select t_end as t

### DIFF
--- a/docker_tasks/vector_ingest/handler.py
+++ b/docker_tasks/vector_ingest/handler.py
@@ -117,6 +117,8 @@ def load_to_featuresdb(filename: str, collection: str):
                     "-nln",
                     f"eis_fire_{collection}",
                     "-overwrite",
+                    "-sql",
+                    f"SELECT fireID, mergeid, t_ed as t from {collection}",
                     "-progress",
                 ],
                 check=True,


### PR DESCRIPTION
**Summary:** Summary of changes

There were some inconsistencies between `newfirepix` and `fireline` and the `t_ed` from `perimeters`. To reconcile those
differences we've added a `t_ed` to `newfirepix` and `fireline`. Now we need to select `t_ed` out as `t` 

## Changes

* see summary above

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests