### PR TITLE
Fix aws provider version for lambda notification module

### DIFF
--- a/docker_tasks/vector_ingest/handler.py
+++ b/docker_tasks/vector_ingest/handler.py
@@ -186,9 +186,7 @@ def handler(event, context):
 
     print(status)
 
-    resp = requests.get(
-        url="https://firenrt.delta-backend.com/refresh"
-    )
+    resp = requests.get(url="https://firenrt.delta-backend.com/refresh")
     print(f"[ REFRESH STATUS CODE ]: {resp.status_code}")
     print(f"[ REFRESH JSON ]: {resp.json()}")
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,5 +1,5 @@
 module "mwaa" {
-  source                           = "https://github.com/NASA-IMPACT/mwaa_tf_module/releases/download/v1.1.1/mwaa_tf_module.zip"
+  source                           = "https://github.com/NASA-IMPACT/mwaa_tf_module/releases/download/v1.1.2/mwaa_tf_module.zip"
   prefix                           = var.prefix
   vpc_id                           = var.vpc_id
   iam_role_additional_arn_policies = merge(module.custom_policy.custom_policy_arns_map)


### PR DESCRIPTION
**Summary:** Summary of changes

Change the link to MWAA source module 

## Changes

* Freeze the version of aws provider to 4.58.0
