### PR TITLE
Allow Developers to `revert` from the UI in Priority-0 Situations

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,10 +10,17 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Check branch
-          if: github.base_ref == 'main' && github.head_ref != 'dev' || github.base_ref == 'production' && github.head_ref != 'main'
           run: |
-            echo "ERROR: You can only merge to main from dev and to production from main"
-            exit 1
+            if [[ $GITHUB_BASE_REF == "main" && ($GITHUB_HEAD_REF != "dev" || $GITHUB_HEAD_REF != "revert-"*) ]];then
+              echo "ERROR: You can only merge to 'main' from 'dev' or a 'revert-*' branch"
+              exit 1
+            fi
+
+            if [[ $GITHUB_BASE_REF == "production" && ($GITHUB_HEAD_REF != "main" || $GITHUB_HEAD_REF != "revert-"*) ]];then
+              echo "ERROR: You can only merge to 'production' from 'main' or a 'revert-*' branch"
+              exit 1
+            fi
+
 
   run-linters:
     name: Run linters

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,14 +11,16 @@ jobs:
       steps:
         - name: Check branch
           run: |
-            if [[ $GITHUB_BASE_REF == "main" && ($GITHUB_HEAD_REF != "dev" || $GITHUB_HEAD_REF != "revert-"*) ]];then
-              echo "ERROR: You can only merge to 'main' from 'dev' or a 'revert-*' branch"
-              exit 1
-            fi
-
-            if [[ $GITHUB_BASE_REF == "production" && ($GITHUB_HEAD_REF != "main" || $GITHUB_HEAD_REF != "revert-"*) ]];then
-              echo "ERROR: You can only merge to 'production' from 'main' or a 'revert-*' branch"
-              exit 1
+            if [[ $GITHUB_BASE_REF == "main" ]]; then
+               if [[ $GITHUB_HEAD_REF != "dev" && $GITHUB_HEAD_REF != "revert-"* ]]; then
+                  echo "ERROR: You can only merge to 'main' from 'dev' or a 'revert-*' branch"
+                  exit 1
+               fi
+            elif [[ $GITHUB_BASE_REF == "production" ]]; then
+               if [[ $GITHUB_HEAD_REF != "main" && $GITHUB_HEAD_REF != "revert-"* ]]; then
+                  echo "ERROR: You can only merge to 'production' from 'main' or a 'revert-*' branch"
+                  exit 1
+               fi
             fi
 
 


### PR DESCRIPTION
### Summary

Fixes first AC of: https://github.com/NASA-IMPACT/veda-analytics/issues/64

Let's talk in tag-up through the implications of tightly coupling IAC and CI/CD b/c now a `revert` semantically means more about code+infra and we can end up in a bad state. I think there's a better practice at hand

### Changes

* allow revert branches to target `main` and `dev`

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests