### PR TITLE
Remove check_output

### DIFF
--- a/docker_tasks/vector_ingest/handler.py
+++ b/docker_tasks/vector_ingest/handler.py
@@ -165,7 +165,6 @@ def load_to_featuresdb(filename: str, collection: str):
                     "-progress",
                 ],
                 check=True,
-                capture_output=True,
             )
         else:
             print("Not a valid fireline collection")


### PR DESCRIPTION
## Summary

Another guess: let's ignore all output (hence removing `check_output`) and hopefully the saved communication between
the child process and parent process leads to more speed


## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests