### PR TITLE
Fix pydantic error because of typing-extension

### DIFF
--- a/docker_tasks/build_stac/requirements.txt
+++ b/docker_tasks/build_stac/requirements.txt
@@ -7,4 +7,5 @@ rasterio==1.3.0
 rio-stac==0.7.0
 shapely
 smart-open==6.3.0
-pydantic==1.9.1
+pydantic==1.10.7
+typing-extensions==4.5.0


### PR DESCRIPTION
# Description
The typing-extension library versioning was causing an issue with pydantic.
The error:
```
Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.10/site-packages/airflow/utils/session.py", line 75, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/operators/ecs.py", line 415, in execute
    self._start_wait_check_task(context)
  File "/usr/local/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/hooks/base_aws.py", line 569, in decorator_f
    return fun(self, *args, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/operators/ecs.py", line 451, in _start_wait_check_task
    self._check_success_task()
  File "/usr/local/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/operators/ecs.py", line 584, in _check_success_task
    raise AirflowException(
airflow.exceptions.AirflowException: This task is not in success state - last 10 logs from Cloudwatch:
    class RegexEvent(BaseEvent):
  File "pydantic/main.py", line 205, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 491, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 421, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 537, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 634, in pydantic.fields.ModelField._type_analysis
  File "pydantic/fields.py", line 641, in pydantic.fields.ModelField._type_analysis
  File "/usr/local/lib/python3.9/typing.py", line 852, in __subclasscheck__
    return issubclass(cls, self.__origin__)
TypeError: issubclass() arg 1 must be a class
```

Pinning the typing-extensions library at version 4.5.0 with pydantic at 1.10.7 solves the issue