### PR TITLE
Fix items dir reference

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -36,7 +36,7 @@ def data_files(data, data_path):
 
 
 def get_items(query):
-    items_path = os.path.join(DATA_PATH, "step_function_inputs")
+    items_path = os.path.join(DATA_PATH, "items")
     return data_files(query, items_path)
 
 


### PR DESCRIPTION
When running `./scripts/item.sh` the items were not being discovered because the directory reference was incorrect. This PR fixes the directory name.