### PR TITLE
Enable convenient, shorter ingest definitions for single-asset items

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support for multi-asset item ingests ([#86](https://github.com/NASA-IMPACT/veda-data-airflow/pull/86))
+- Simple single-asset item ingests supported again ([#87](https://github.com/NASA-IMPACT/veda-data-airflow/pull/87))
+
 ### Changed 
 
 - Insert collections via ingestor API rather than directly with pgstac ([#13](https://github.com/NASA-IMPACT/veda-data-airflow/pull/13))

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -104,15 +104,20 @@ def group_by_item(discovered_files: List[str], id_regex: str, assets: dict) -> d
         items_with_assets.append(item)
     return items_with_assets
 
+
 def construct_single_asset_items(discovered_files: List[str]) -> dict:
     items_with_assets = []
     for uri in discovered_files:
         # Each file gets its matched asset type and id
         filename = uri.split("/")[-1]
         prefix = "/".join(uri.split("/")[:-1])
-        item = { "item_id": filename, "assets": { "cog_default": { "href": f"{prefix}/{filename}" } } }
+        item = {
+            "item_id": filename,
+            "assets": {"cog_default": {"href": f"{prefix}/{filename}"}},
+        }
         items_with_assets.append(item)
     return items_with_assets
+
 
 def generate_payload(s3_prefix_key: str, payload: dict):
     """Generate a payload and write it to an S3 file.
@@ -196,12 +201,13 @@ def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=No
         items_with_assets = construct_single_asset_items(file_uris)
 
     if len(items_with_assets) == 0:
-        raise ValueError(f"No items could be constructed for files at bucket: {bucket}, prefix: {prefix}")
+        raise ValueError(
+            f"No items could be constructed for files at bucket: {bucket}, prefix: {prefix}"
+        )
 
     # Update IDs using id_template
     for item in items_with_assets:
         item["item_id"] = id_template.format(item["item_id"])
-
 
     if dry_run:
         print(f"-DRYRUN- Discovered {len(items_with_assets)} items")

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -113,7 +113,13 @@ def construct_single_asset_items(discovered_files: List[str]) -> dict:
         prefix = "/".join(uri.split("/")[:-1])
         item = {
             "item_id": filename,
-            "assets": {"cog_default": {"href": f"{prefix}/{filename}"}},
+            "assets": {
+                "cog_default": {
+                    "title": "Default COG Layer",
+                    "description": "Cloud optimized default layer to display on map",
+                    "href": f"{prefix}/{filename}",
+                }
+            },
         }
         items_with_assets.append(item)
     return items_with_assets


### PR DESCRIPTION
**Summary:** Summary of changes

This PR is aimed at simplifying the definition of single-asset item ingests. If no `assets` field is provided to discovery, it will now assume that the older `cog_default` strategy is appropriate for registering item assets.


## Changes

* Fail faster and under more scenarios (in particular: failure to discover anything is now a DAG run failure)
* Single asset ingests now look much more like they did in prior versions of the discovery DAG

## PR Checklist

- [x] Update CHANGELOG
- [x] Ad-hoc testing - Deploy changes and test manually
