### PR TITLE
FWI Dataset remove ogr2ogr progress

### DIFF
--- a/docker_tasks/vector_ingest/handler.py
+++ b/docker_tasks/vector_ingest/handler.py
@@ -237,7 +237,7 @@ def load_to_featuresdb(filename: str, collection: str):
                 filename,
                 "-nln",
                 f"eis_fire_{collection}",
-                "-append"
+                "-append",
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/docker_tasks/vector_ingest/handler.py
+++ b/docker_tasks/vector_ingest/handler.py
@@ -237,8 +237,7 @@ def load_to_featuresdb(filename: str, collection: str):
                 filename,
                 "-nln",
                 f"eis_fire_{collection}",
-                "-append",
-                "-progress",
+                "-append"
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
FWI Dataset remove ogr2ogr progress because of this error:

`Warning 6: Progress turned off as fast feature count is not available.`