### PR TITLE
fix: coalesce empty string to false

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -244,7 +244,7 @@ resource "null_resource" "update_cloudfront" {
     always_run = "${timestamp()}"
   }
 
-  count = var.cloudfront_id ? 1 : 0
+  count = coalesce(var.cloudfront_id, false) ? 1 : 0
 
   provisioner "local-exec" {
     command = "${path.module}/cf_update.sh ${var.cloudfront_id} workflows_api_origin \"${aws_apigatewayv2_api.workflows_http_api.api_endpoint}\""


### PR DESCRIPTION
Fixes deployment failures if CLOUDFRONT_ID is using default value (empty string).