### PR TITLE
Fix workflows publish collections

### DIFF
--- a/workflows_api/runtime/src/auth.py
+++ b/workflows_api/runtime/src/auth.py
@@ -70,4 +70,4 @@ def get_username(claims: security.HTTPBasicCredentials = Depends(decode_token)):
 def get_token(
     token: security.HTTPAuthorizationCredentials = Depends(token_scheme),
 ):
-    return token
+    return token.credentials

--- a/workflows_api/runtime/src/collection_publisher.py
+++ b/workflows_api/runtime/src/collection_publisher.py
@@ -21,14 +21,12 @@ class CollectionPublisher:
         does necessary preprocessing,
         and loads into the PgSTAC collection table
         """
-        collection = collection.json(by_alias=True)
-
         url = f"{ingest_api}/collections"
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
-        response = requests.post(url, json=collection, headers=headers)
+        response = requests.post(url, data=collection.json(by_alias=True), headers=headers)
         if response.status_code == 200:
             print("Success:", response.json())
         else:
@@ -161,14 +159,13 @@ class Publisher:
         does necessary preprocessing,
         and loads into the PgSTAC collection table
         """
-        collection = collection.json(by_alias=True)
-
+        
         url = f"{ingest_api}/collections"
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
-        response = requests.post(url, json=collection, headers=headers)
+        response = requests.post(url, data=collection.json(by_alias=True), headers=headers)
         if response.status_code == 200:
             print("Success:", response.json())
         else:


### PR DESCRIPTION
There are two changes in this PR:

- `requests` POST expects the `data` argument when passing JSON instead of `json` which is for dicts. I tried exported the pydantic model to dict but there was an issue with datetime serialization. 
- The `get_token()` function was returning an instance of [HTTPBearer](https://fastapi.tiangolo.com/reference/security/#fastapi.security.HTTPBearer) but we need pass just the credentials to the publish endpoint

