### PR TITLE
fix: default dev/test to smaller environment

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -10,6 +10,7 @@ module "mwaa" {
   mwaa_variables_json_file_id_path = { file_path = local_file.mwaa_variables.filename, file_id = local_file.mwaa_variables.id }
   stage                            = var.stage
   airflow_version                  = "2.4.3"
+  environment_class                = lookup(var.mwaa_environment_class, var.stage, "mw1.small")
   min_workers                      = lookup(var.min_workers, var.stage, 1)
   ecs_containers = [
     {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -53,6 +53,15 @@ variable "min_workers" {
     production = 3
   }
 }
+
+variable "mwaa_environment_class" {
+  type = map(string)
+  default = {
+    dev        = "mw1.small"
+    staging    = "mw1.medium"
+    production = "mw1.medium"
+  }
+}
 variable "vector_secret_name" {
   type = string
 }


### PR DESCRIPTION
## Changes

* Configures MWAA environment size to align with min workers
* As-is, `dev` and `sit` will be changed to use a smaller environment on next deployment. `staging` and `production` will be unchanged.

## PR Checklist

- [ ] Update CHANGELOG
~~- [ ] Unit tests~~
- [x] Ad-hoc testing - `terraform plan` runs successfully, updates will be run in-place
~~- [ ] Integration tests~~