### PR TITLE
Fix transfer util in transfer DAG

### DIFF
--- a/dags/veda_data_pipeline/groups/transfer_group.py
+++ b/dags/veda_data_pipeline/groups/transfer_group.py
@@ -65,9 +65,13 @@ def subdag_transfer():
                         ],
                         "environment": [
                             {
-                                "name": "EXTERNAL_ROLE_ARN",
+                                "name": "ASSUME_ROLE_READ_ARN",
                                 "value": Variable.get(
                                     "ASSUME_ROLE_READ_ARN", default_var=""
+                                ),
+                                "name": "ASSUME_ROLE_WRITE_ARN",
+                                "value": Variable.get(
+                                    "ASSUME_ROLE_WRITE_ARN", default_var=""
                                 ),
                             },
                         ],

--- a/dags/veda_data_pipeline/groups/transfer_group.py
+++ b/dags/veda_data_pipeline/groups/transfer_group.py
@@ -65,13 +65,9 @@ def subdag_transfer():
                         ],
                         "environment": [
                             {
-                                "name": "ASSUME_ROLE_READ_ARN",
+                                "name": "EXTERNAL_ROLE_ARN",
                                 "value": Variable.get(
                                     "ASSUME_ROLE_READ_ARN", default_var=""
-                                ),
-                                "name": "ASSUME_ROLE_WRITE_ARN",
-                                "value": Variable.get(
-                                    "ASSUME_ROLE_WRITE_ARN", default_var=""
                                 ),
                             },
                         ],

--- a/dags/veda_data_pipeline/groups/transfer_group.py
+++ b/dags/veda_data_pipeline/groups/transfer_group.py
@@ -29,7 +29,7 @@ def transfer_data(ti):
     # (event, chunk_size=2800, role_arn=None, bucket_output=None):
     return data_transfer_handler(event=config, role_arn=role_arn)
 
-
+# TODO: cogify_transfer handler is missing arg parser so this subdag will not work
 def subdag_transfer():
     with TaskGroup(**group_kwgs) as discover_grp:
         cogify_branching = BranchPythonOperator(

--- a/dags/veda_data_pipeline/utils/transfer.py
+++ b/dags/veda_data_pipeline/utils/transfer.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import boto3
+from airflow.exceptions import AirflowException
 
 
 def assume_role(role_arn, session_name="veda-data-airflow_s3-discovery"):
@@ -46,6 +47,7 @@ def transfer_files_within_s3(
 ):
     for file_key in matching_files:
         filename = file_key.split("/")[-1]
+        print(f"Transferring file: {filename}")
         target_key = f"{collection}/{filename}"
         copy_source = {"Bucket": origin_bucket, "Key": file_key}
 
@@ -56,7 +58,7 @@ def transfer_files_within_s3(
                 Bucket=destination_bucket, Key=target_key
             )
             target_etag = target_metadata["ETag"]
-        except s3_client.exceptions.NoSuchKey:
+        except s3_client.exceptions.ClientError:
             target_etag = ""
 
         s3_client.copy_object(
@@ -67,14 +69,13 @@ def transfer_files_within_s3(
         )
 
 
-def data_transfer_handler(event, role_arn=None, bucket_output=None):
+def data_transfer_handler(event, role_arn=None):
     origin_bucket = event.get("origin_bucket")
     origin_prefix = event.get("origin_prefix")
     filename_regex = event.get("filename_regex")
     target_bucket = event.get("target_bucket")
     collection = event.get("collection")
 
-    role_arn = os.environ.get("ASSUME_ROLE_ARN", role_arn)
     kwargs = assume_role(role_arn=role_arn) if role_arn else {}
     s3client = boto3.client("s3", **kwargs)
     matching_files = get_matching_files(
@@ -83,6 +84,10 @@ def data_transfer_handler(event, role_arn=None, bucket_output=None):
         prefix=origin_prefix,
         regex_pattern=filename_regex,
     )
+
+    if len(matching_files)==0:
+        raise AirflowException("No matching files found")
+
     if not event.get("dry_run"):
         transfer_files_within_s3(
             s3_client=s3client,

--- a/dags/veda_data_pipeline/utils/transfer.py
+++ b/dags/veda_data_pipeline/utils/transfer.py
@@ -58,8 +58,9 @@ def transfer_files_within_s3(
                 Bucket=destination_bucket, Key=target_key
             )
             target_etag = target_metadata["ETag"]
-        except s3_client.exceptions.ClientError:
-            target_etag = ""
+        except s3_client.exceptions.ClientError as err:
+            if err.response["Error"]["Code"] == "404":
+                target_etag = ""
 
         s3_client.copy_object(
             CopySource=copy_source,

--- a/docker_tasks/cogify_transfer/handler.py
+++ b/docker_tasks/cogify_transfer/handler.py
@@ -3,7 +3,6 @@ import re
 import tempfile
 
 import boto3
-from rio_cogeo.cogeo import cog_translate
 
 
 def assume_role(role_arn, session_name="veda-airflow-pipelines_transfer_files"):
@@ -49,36 +48,45 @@ def transfer_file(s3_client, file_key, local_file_path, destination_bucket, coll
 
 
 def cogify_transfer_handler(event, context):
-    kwargs = {}
-    if external_role_arn := os.environ["EXTERNAL_ROLE_ARN"]:
-        creds = assume_role(external_role_arn, "veda-data-pipelines_data-transfer")
-        kwargs = {
-            "aws_access_key_id": creds["AccessKeyId"],
-            "aws_secret_access_key": creds["SecretAccessKey"],
-            "aws_session_token": creds["SessionToken"],
+    kwargs_read = {}
+    if external_role_read_arn := os.environ["ASSUME_ROLE_READ_ARN"]:
+        creds = assume_role(external_role_read_arn, "veda-data-pipelines_data-transfer-read")
+        kwargs_read = {
+            "aws_access_key_id": creds["aws_access_key_id"],
+            "aws_secret_access_key": creds["aws_secret_access_key"],
+            "aws_session_token": creds["aws_session_token"],
         }
-    source_s3 = boto3.client("s3")
-    target_s3 = boto3.client("s3", **kwargs)
+    
+    kwargs_write = {}
+    if external_role_write_arn := os.environ["ASSUME_ROLE_WRITE_ARN"]:
+        creds = assume_role(external_role_write_arn, "veda-data-pipelines_data-transfer-read")
+        kwargs_write = {
+            "aws_access_key_id": creds["aws_access_key_id"],
+            "aws_secret_access_key": creds["aws_secret_access_key"],
+            "aws_session_token": creds["aws_session_token"],
+        }
+        
+    source_s3 = boto3.client("s3", **kwargs_read)
+    target_s3 = boto3.client("s3", **kwargs_write)
 
     origin_bucket = event.get("origin_bucket")
     origin_prefix = event.get("origin_prefix")
     regex_pattern = event.get("filename_regex")
     target_bucket = event.get("target_bucket", "veda-data-store-staging")
     collection = event.get("collection")
+    dry_run = event.get("dry_run")
 
     matching_files = get_matching_files(
         source_s3, origin_bucket, origin_prefix, regex_pattern
     )
-    if not event.get("dry_run"):
+    if not dry_run:
         for origin_key in matching_files:
-            with tempfile.NamedTemporaryFile() as local_tif, tempfile.NamedTemporaryFile() as local_cog:
+            with tempfile.NamedTemporaryFile() as local_tif:
                 local_tif_path = local_tif.name
-                local_cog_path = local_cog.name
                 source_s3.download_file(origin_bucket, origin_key, local_tif_path)
-                cog_translate(local_tif_path, local_cog_path, quiet=True)
                 filename = origin_key.split("/")[-1]
                 destination_key = f"{collection}/{filename}"
-                target_s3.upload_file(local_cog_path, target_bucket, destination_key)
+                target_s3.upload_file(local_tif_path, target_bucket, destination_key)
     else:
         print(
             f"Would have copied {len(matching_files)} files from {origin_bucket} to {target_bucket}"


### PR DESCRIPTION
Changes to `utils/transfer.py` process to enable transfers within MCP buckets

The `cogify_transfer` handler still need works to make operational however `utils/transfer.py` will work for straight transfers in MCP.

To enable PUT operations, the assume role ENV should be set to:
`ASSUME_ROLE_ARNS='["arn:aws:iam::114506680961:role/veda-data-manager","arn:aws:iam::114506680961:role/veda-data-manager"]'`