### PR TITLE
Transfer DAG change s3 copy_object logic

### DIFF
--- a/dags/veda_data_pipeline/utils/transfer.py
+++ b/dags/veda_data_pipeline/utils/transfer.py
@@ -58,16 +58,21 @@ def transfer_files_within_s3(
                 Bucket=destination_bucket, Key=target_key
             )
             target_etag = target_metadata["ETag"]
+            print(f"File already exists, checking Etag: {filename}")
+            s3_client.copy_object(
+                    CopySource=copy_source,
+                    Bucket=destination_bucket,
+                    Key=target_key,
+                    CopySourceIfNoneMatch=target_etag,
+                )
         except s3_client.exceptions.ClientError as err:
             if err.response["Error"]["Code"] == "404":
-                target_etag = ""
-
-        s3_client.copy_object(
-            CopySource=copy_source,
-            Bucket=destination_bucket,
-            Key=target_key,
-            CopySourceIfNoneMatch=target_etag,
-        )
+                print(f"Copying file: {filename}")
+                s3_client.copy_object(
+                    CopySource=copy_source,
+                    Bucket=destination_bucket,
+                    Key=target_key
+                )
 
 
 def data_transfer_handler(event, role_arn=None):


### PR DESCRIPTION
If a file already existed in a bucket, the following error occurred:

`botocore.exceptions.ClientError: An error occurred (PreconditionFailed) when calling the CopyObject operation: At least one of the pre-conditions you specified did not hold`

The PR changes the conditions for how copy_object is called.

This change was tested in SIT
