### PR TITLE
Update mwaa module to 1.1.9

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,5 +1,5 @@
 module "mwaa" {
-  source                           = "https://github.com/NASA-IMPACT/mwaa_tf_module/releases/download/v1.1.7.0/mwaa_tf_module.zip"
+  source                           = "https://github.com/NASA-IMPACT/mwaa_tf_module/releases/download/v1.1.9/mwaa_tf_module.zip"
   prefix                           = var.prefix
   vpc_id                           = var.vpc_id
   iam_role_additional_arn_policies = merge(module.custom_policy.custom_policy_arns_map)


### PR DESCRIPTION
Update mwaa module to 1.1.9 to address https://github.com/NASA-IMPACT/veda-data-airflow/issues/119

The module update removed `--size-only` from the s3 DAG sync. https://github.com/NASA-IMPACT/mwaa_tf_module/blob/5768ca2af2b05c5d57d276aa972bba4dd1bde3ac/platform/s3_bucket/main.tf#L65