### PR TITLE
fix: add pre=true to check_dates validator

### DIFF
--- a/workflows_api/runtime/src/schema_helpers.py
+++ b/workflows_api/runtime/src/schema_helpers.py
@@ -43,7 +43,7 @@ class TemporalExtent(BaseModel):
     startdate: datetime
     enddate: datetime
 
-    @root_validator
+    @root_validator(pre=True)
     def check_dates(cls, v):
         if v["startdate"] >= v["enddate"]:
             raise ValueError("Invalid extent - startdate must be before enddate")


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [VEDA-113: Develop amazing new feature](https://github.com/NASA-IMPACT/veda-data-airflow/issues/113)

## Changes

* add `pre=True` to validator. Context here https://github.com/NASA-IMPACT/veda-stac-ingestor/issues/75 

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests