### PR TITLE
fix existing tests to run

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = **/tests/**

--- a/docker_tasks/build_stac/tests/test_handler.py
+++ b/docker_tasks/build_stac/tests/test_handler.py
@@ -58,7 +58,7 @@ def test_routing_regex_event():
         events.CmrEvent,
         MagicMock(),
     ) as not_called_mock:
-        handler.handler(regex_event, None)
+        handler.handler(regex_event)
 
     called_mock.assert_called_once_with(events.RegexEvent.parse_obj(regex_event))
     assert not not_called_mock.call_count
@@ -83,7 +83,7 @@ def test_routing_cmr_event():
         events.RegexEvent,
         MagicMock(),
     ) as not_called_mock:
-        handler.handler(cmr_event, None)
+        handler.handler(cmr_event)
 
     called_mock.assert_called_once_with(events.CmrEvent.parse_obj(cmr_event))
     assert not not_called_mock.call_count
@@ -98,4 +98,4 @@ def test_routing_unexpected_event(bad_event):
     Ensure that a malformatted event raises a validation error
     """
     with pytest.raises(ValidationError):
-        handler.handler(bad_event, None)
+        handler.handler(bad_event)

--- a/docker_tasks/build_stac/tests/test_regex.py
+++ b/docker_tasks/build_stac/tests/test_regex.py
@@ -82,6 +82,11 @@ from utils import regex
             ("s3://foo/bar/foo_20050402_bar.tif", "year"),
             (datetime(2005, 1, 1), datetime(2005, 12, 31), None),
         ),
+        (
+            # Single date converted to year range - %Y
+            ("s3://foo/bar/foo_20050402_bar.tif", "day"),
+            (datetime(2005, 4, 2, 0, 0), datetime(2005, 4, 2, 23, 59, 59), None),
+        ),
     ],
 )
 def test_date_extraction(test_input, expected):

--- a/scripts/item.py
+++ b/scripts/item.py
@@ -13,7 +13,7 @@ def insert_items(files):
     for filename in files:
         print(filename)
         events = json.load(open(filename))
-        if type(events) != list:
+        if not isinstance(events, list):
             events = [events]
         for event in events:
             raw_data = f"dags trigger veda_discover --conf '{json.dumps(event)}'"


### PR DESCRIPTION
**Summary:** 
Fixes existing tests to run.  coverage is still low, but tests will now run.

Addresses veda-data-airflow #140 

## Changes
Adds missing test case for the regex test.
Removes  extra`None` parameter that was previously passed to handler
Removes cmr test as this appeared unsupported.

<img width="1019" alt="Screenshot 2024-04-30 at 3 18 34 PM" src="https://github.com/NASA-IMPACT/veda-data-airflow/assets/7388976/37ee5ce8-d216-43e5-ab70-0602371e97c2">
