### PR TITLE
add DAG integrity test

### DIFF
--- a/dags/veda_data_pipeline/integrity_tests/conftest.py
+++ b/dags/veda_data_pipeline/integrity_tests/conftest.py
@@ -1,0 +1,29 @@
+import os
+
+"""
+Define any env variables expected in test files.
+Airflow variables are in format AIRFLOW_VAR_XXX
+"""
+TEST_ENV_VARS = {
+    'AIRFLOW_VAR_MWAA_STACK_CONF': "{\"foo\": \"bar\"}",
+    'AIRFLOW_VAR_VECTOR_SECRET_NAME': "{\"foo\": \"bar\"}"
+}
+
+
+def pytest_configure(config):
+    """Configure and init envvars for airflow."""
+    print("loading PYTEST CONF")
+    config.old_env = {}
+    for key, value in TEST_ENV_VARS.items():
+        config.old_env[key] = os.getenv(key)
+        os.environ[key] = value
+        print('updating: ', key, value)
+
+
+def pytest_unconfigure(config):
+    """Restore envvars to old values."""
+    for key, value in config.old_env.items():
+        if value is None:
+            del os.environ[key]
+        else:
+            os.environ[key] = value

--- a/dags/veda_data_pipeline/integrity_tests/requirements.txt
+++ b/dags/veda_data_pipeline/integrity_tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+apache-airflow
+coverage

--- a/dags/veda_data_pipeline/integrity_tests/test_dag_integrity.py
+++ b/dags/veda_data_pipeline/integrity_tests/test_dag_integrity.py
@@ -1,0 +1,30 @@
+"""Test integrity of dags."""
+
+import importlib
+import os
+
+import pytest
+from airflow import models as af_models
+from airflow.utils.dag_cycle_tester import check_cycle
+
+
+DAG_PATH = os.path.dirname(os.path.dirname(__file__))
+
+DAG_FILES = [f for f in os.listdir(DAG_PATH) if f.endswith('.py')]
+
+print("Testing DAG_FILES", DAG_FILES)
+
+@pytest.mark.parametrize('dag_file', DAG_FILES)
+def test_dag_integrity(dag_file):
+    """Import dag files and check for DAG."""
+    print("DAG_PATH", DAG_PATH)
+    module_name, _ = os.path.splitext(dag_file)
+    module_path = os.path.join(DAG_PATH, dag_file)
+    mod_spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(mod_spec)
+    mod_spec.loader.exec_module(module)
+
+    dag_objects = [var for var in vars(module).values() if isinstance(var, af_models.DAG)]
+
+    for dag in dag_objects:
+        check_cycle(dag)


### PR DESCRIPTION
**Summary:** 
Based on the [Data’s Inferno: 7 Circles of Data Testing Hell with Airflow](https://medium.com/wbaa/datas-inferno-7-circles-of-data-testing-hell-with-airflow-cef4adff58d8) article from ING bank, I have implemented a DAG integrity test.  This will look at all files in the veda-data-pipeline directory to ensure that they are valid DAGs and do not contain a cycle.


Addresses [VEDA--148: Add test to ensure that DAGs are valid ](https://github.com/NASA-IMPACT/veda-data-airflow/issues/148)

## Changes

Adds necessary requirements.txt and fixture to run a test that will look at all DAGs by running `pytest -s veda_data_pipeline/integrity_tests/test_dag_integrity.py` in the `veda-data-airflow/dags` directory

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests