### PR TITLE
chore: enable previously disabled test in dockerfile

### DIFF
--- a/docker_tasks/build_stac/Dockerfile
+++ b/docker_tasks/build_stac/Dockerfile
@@ -16,11 +16,11 @@ ENV GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR GDAL_MAX_DATASET_POOL_SIZE=1024 GDAL_
 
 
 ## Test target
-#FROM production AS test
-#
-#COPY requirements-test.txt requirements-test.txt
-#RUN pip install -r requirements-test.txt
-#RUN rm requirements-test.txt
-#
-#COPY tests ./tests
-#CMD ["pytest", "tests"]
+FROM production AS test
+
+COPY requirements-test.txt requirements-test.txt
+RUN pip install -r requirements-test.txt
+RUN rm requirements-test.txt
+
+COPY tests ./tests
+CMD ["pytest", "tests"]


### PR DESCRIPTION
**Summary:** Summary of changes

In https://github.com/NASA-IMPACT/veda-data-airflow/pull/144 we fixed the unit tests around the build_stac function to actually run and pass.  The test step was originally disabled in the Dockerfile.  The intent of this is to enable those tests to run on each build.

## Changes
Uncomment out the test section of the dockerfile.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests