### PR TITLE
fix(tf): wait for image to be pushed before using in lambda

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -235,6 +235,9 @@ resource "aws_lambda_function" "workflows_api_handler" {
   timeout       = 30
   image_uri = "${aws_ecr_repository.workflows_api_lambda_repository.repository_url}:latest"
 
+  # prevents handler from instantiating if provisioner has not created an image
+  depends_on = [ null_resource.if_change_run_provisioner ]
+
   vpc_config {
     subnet_ids = var.subnet_ids
     security_group_ids = [aws_security_group.workflows_api_handler_sg.id]


### PR DESCRIPTION
**Summary:** 

Adds dependency to make sure that `image:latest` exists before creating the lambda resource.
Prevents error seen [here](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/9288738466/job/25565157689).

TF plan and deploy runs on SIT. Haven't tested on a new environment yet (error only appears if ECR repo is fresh)