### PR TITLE
Add alias for missing fields in schema

### DIFF
--- a/workflows_api/runtime/src/schemas.py
+++ b/workflows_api/runtime/src/schemas.py
@@ -191,8 +191,8 @@ class Dataset(BaseModel):
     title: str
     description: str
     license: str
-    is_periodic: Optional[bool] = False
-    time_density: Optional[str] = None
+    is_periodic: Optional[bool] = Field(default=False, alias='dashboard:is_periodic')
+    time_density: Optional[str] = Field(default=None, alias='dashboard:time_density')
     links: Optional[List[Link]] = []
     discovery_items: List[S3Input]
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses input values not being reflected in `is_periodic` and `time_density`

## Changes

* Added alias names `dashboard:is_periodic` and `dashboard:time_density` to schema.
