### PR TITLE
Branch single assets to correct path

### DIFF
--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -226,10 +226,12 @@ def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=No
     if len(file_uris) == 0:
         raise ValueError(f"No files discovered at bucket: {bucket}, prefix: {prefix}")
 
-    # out of convenience, we might not always want to explicitly define assets
-    if assets and len(assets) > 1:
+    # group only if more than 1 assets
+    if assets and len(assets.keys()) > 1:
         items_with_assets = group_by_item(file_uris, id_regex, assets)
     else:
+        # out of convenience, we might not always want to explicitly define assets
+        # or if only a single asset is defined, follow default flow
         items_with_assets = construct_single_asset_items(file_uris, assets)
 
     if len(items_with_assets) == 0:

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -118,7 +118,7 @@ def group_by_item(discovered_files: List[str], id_regex: str, assets: dict) -> d
 
 def construct_single_asset_items(discovered_files: List[str], assets: dict|None) -> dict:
     items_with_assets = []
-    asset_key = "cog_default"
+    asset_key = "default"
     asset_value = {}
     if assets:
         asset_key = list(assets.keys())[0]


### PR DESCRIPTION
# Description

## Issue
Even for collections with single item assets, if we provide the "assets" input with just a single asset, it still goes through the grouping path where the `id_regex` is required and the name is changed based on the `id_template` - making it impossible for the item_id to be the filename.

## Solution
If the provided assets only contains one asset, follow the same process as when no assets is provided and a default asset is created.

# Testing
Deployed to `ghgc-smce-dev` environment using `veda-deploy`.
Tested with the following configs

<details>
<summary>
emit-ch4plume-v1.json
</summary>

```json
{
    "assets": {
        "ch4-plume-emissions": {
            "description": "Methane plume complexes from point source emitters.",
            "regex": ".*.tif$",
            "title": "EMIT Methane Point Source Plume Complexes"
        }
    },
    "bucket": "lp-prod-protected",
    "collection": "emit-ch4plume-v1",
    "filename_regex": ".*.tif$",
    "prefix": "EMITL2BCH4PLM.001/"
}
```

</details>

Worked as expected with the correct `item_id` as seen here - https://dev.ghg.center/api/stac/collections/emit-ch4plume-v1/items.

Not passing any assets created a `cog_default` asset.