### PR TITLE
docs: utility for retrieving .env variables from aws secretsmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This project uses Terraform modules to deploy Apache Airflow and related AWS res
 
 ### Make sure that environment variables are set
 
-[.env.example`](./.env.example) contains the environment variables which are necessary to deploy. Copy this file and update its contents with actual values. The deploy script will `source` and use this file during deployment when provided through the command line:
+[`.env.example`](..env.example) contains the environment variables which are necessary to deploy. Copy this file and update its contents with actual values. The deploy script will `source` and use this file during deployment when provided through the command line:
 
 ```bash
 # Copy .env.example to a new file
@@ -55,7 +55,16 @@ $bash ./scripts/deploy.sh .env <<< init
 $bash ./scripts/deploy.sh .env <<< deploy
 ```
 
-**Note:** Be careful not to check in `.env` (or whatever you called your env file) when committing work.
+### Fetch environment variables using AWS CLI
+
+To retrieve the variables for a stage that has been previously deployed, the secrets manager can be used to quickly populate an .env file with [`scripts/sync-env-local.sh`](scripts/sync-env-local.sh). 
+
+```
+./scripts/sync-env-local.sh <app-secret-name>
+```
+
+> [!IMPORTANT] 
+> Be careful not to check in `.env` (or whatever you called your env file) when committing work.
 
 Currently, the client id and domain of an existing Cognito user pool programmatic client must be supplied in [configuration](ingest_api/infrastructure/config.py) as `VEDA_CLIENT_ID` and `VEDA_COGNITO_DOMAIN` (the [veda-auth project](https://github.com/NASA-IMPACT/veda-auth) can be used to deploy a Cognito user pool and client). To dispense auth tokens via the workflows API swagger docs, an administrator must add the ingest API lambda URL to the allowed callbacks of the Cognito client.
 

--- a/scripts/sync-env-local.sh
+++ b/scripts/sync-env-local.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Use this script to load environment variables for a deployment from AWS Secrets
+
+echo Loading environment secrets from $1
+aws secretsmanager get-secret-value --secret-id $1 --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' > .env


### PR DESCRIPTION
**Summary:** 
This PR adds a small utility script and documentation for retrieving shared env configuration from secretsmanager (if present). Supports sharing configuration for manual deployments to SIT stack if used.

## Changes

* Adds documentation for retrieving shared configuration variables from aws secretsmanager
* Fixes README typo

## PR Checklist

- ~Update CHANGELOG~ N/A
- ~Unit tests~ N/A
- [x] Ad-hoc testing - Confirmed that sync env vars local script can retrieve existing SIT env vars from secretsmanager
- ~Integration tests~ N/A