### PR TITLE
Support collection multiple config

### DIFF
--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -31,7 +31,7 @@ def generate_dags():
         collections = json.loads(collections)
 
         # Allow the file content to be either one config or a list of configs
-        if type(collections, dict):
+        if type(collections) is dict:
             collections = [collections]
         scheduled_collections = [
             collection

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -5,13 +5,15 @@ These DAGs are used to discover and ingest items for each collection.
 
 from airflow.models.variable import Variable
 
-
 from veda_data_pipeline.veda_discover_pipeline import get_discover_dag
 
 
 def generate_dags():
     import boto3
     import json
+
+    from pathlib import Path
+
 
     mwaa_stac_conf = Variable.get("MWAA_STACK_CONF", deserialize_json=True)
     bucket = mwaa_stac_conf["EVENT_BUCKET"]
@@ -23,12 +25,25 @@ def generate_dags():
         key = file_["Key"]
         if key.endswith("/"):
             continue
+        file_name = Path(key).stem
         result = client.get_object(Bucket=bucket, Key=key)
-        collection = result["Body"].read().decode()
-        collection = json.loads(collection)
-        if collection.get("schedule"):
+        collections = result["Body"].read().decode()
+        collections = json.loads(collections)
+
+        # Allow the file content to be either one config or a list of configs
+        if type(collections, dict):
+            collections = [collections]
+        scheduled_collections = [
+            collection
+                for collection in collections
+                    if collection.get("schedule")
+            ]
+        for idx, collection in enumerate(scheduled_collections):
+            id = f"discover-{file_name}"
+            if idx > 0:
+                id = f"{id}-{idx}"
             get_discover_dag(
-                id=f"discover-{collection['collection']}", event=collection
+                id=id, event=collection
             )
 
 

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -27,23 +27,23 @@ def generate_dags():
             continue
         file_name = Path(key).stem
         result = client.get_object(Bucket=bucket, Key=key)
-        collections = result["Body"].read().decode()
-        collections = json.loads(collections)
+        discovery_configs = result["Body"].read().decode()
+        discovery_configs = json.loads(discovery_configs)
 
         # Allow the file content to be either one config or a list of configs
-        if type(collections) is dict:
-            collections = [collections]
-        scheduled_collections = [
-            collection
-                for collection in collections
-                    if collection.get("schedule")
+        if type(discovery_configs) is dict:
+            discovery_configs = [discovery_configs]
+        scheduled_discovery_configs = [
+            discovery_config
+                for discovery_config in discovery_configs
+                    if discovery_config.get("schedule")
             ]
-        for idx, collection in enumerate(scheduled_collections):
+        for idx, discovery_config in enumerate(scheduled_discovery_configs):
             id = f"discover-{file_name}"
             if idx > 0:
                 id = f"{id}-{idx}"
             get_discover_dag(
-                id=id, event=collection
+                id=id, event=discovery_config
             )
 
 


### PR DESCRIPTION
## Why?
For some collections in GHG with data hosted in DAACs, the data files come from different prefixes. See [this issue].(https://github.com/US-GHG-Center/ghgc-architecture/issues/292#issue-2396111574)

For scheduling collections like these, we should support having multiple configs in the same file while supporting the existing pattern of only having a single config in a file.

## How?
When reading scheduled discoveries,
1. allow the file to have either one config or a list of configs
2. use the filename to name the scheduled discovery dag

## Tested?
Deployed to `ghgc-smce-dev` environment via `veda-deploy` with the following file:

<details>
<summary>
lpjeosim-wetlandch4-monthgrid-v2.json
</summary>

```json
[
    {
        "collection": "lpjeosim-wetlandch4-monthgrid-v2",
        "bucket": "lp-prod-protected",
        "prefix": "LPJ_EOSIM_L2_MCH4E.001/",
        "filename_regex": ".*LPJ_EOSIM_L2_MCH4E_.*.tif$",
        "assets": {
            "ensemble-mean-ch4-wetlands-emissions": {
                "title": "(Monthly) Wetland Methane Emissions, Ensemble Mean LPJ-EOSIM Model v2",
                "description": "Methane emissions from wetlands in units of grams of methane per meter squared per month. Ensemble of multiple climate forcing data sources input to LPJ-EOSIM model.",
                "regex": ".*LPJ_EOSIM_L2_MCH4E_ensemble_mean_001.*.tif$"
            },
            "era5-ch4-wetlands-emissions": {
                "title": "(Monthly) Wetland Methane Emissions, ERA5 LPJ-EOSIM Model v2",
                "description": "Methane emissions from wetlands in units of grams of methane per meter squared per month. ECMWF Re-Analysis (ERA5) as input to LPJ-EOSIM model.",
                "regex": ".*LPJ_EOSIM_L2_MCH4E_ERA5_001.*.tif$"
            },
            "merra2-ch4-wetlands-emissions": {
                "title": "(Monthly) Wetland Methane Emissions, MERRA-2 LPJ-EOSIM Model v2",
                "description": "Methane emissions from wetlands in units of grams of methane per meter squared per month. Modern-Era Retrospective analysis for Research and Applications Version 2 (MERRA-2) data as input to LPJ-EOSIM model.",
                "regex": ".*LPJ_EOSIM_L2_MCH4E_MERRA2_001.*.tif$"
            }
        },
        "id_regex": ".*_(.*).tif$",
        "id_template": "lpjeosim-wetlandch4-monthgrid-v2-{}",
        "datetime_range": "month",
        "schedule": "18 17 * * *"
    },
    {
        "collection": "lpjeosim-wetlandch4-monthgrid-v2",
        "bucket": "lp-prod-protected",
        "prefix": "LPJ_EOSIM_L2_MCH4E_LL.001/",
        "filename_regex": ".*LPJ_EOSIM_L2_MCH4E_LL.*.tif$",
        "assets": {
            "ensemble-mean-ch4-wetlands-emissions": {
                "title": "(Monthly) Wetland Methane Emissions, Ensemble Mean LPJ-EOSIM Model v2",
                "description": "Methane emissions from wetlands in units of grams of methane per meter squared per month. Ensemble of multiple climate forcing data sources input to LPJ-EOSIM model.",
                "regex": ".*LPJ_EOSIM_L2_MCH4E_LL_ensemble_mean_001.*.tif$"
            },
            "era5-ch4-wetlands-emissions": {
                "title": "(Monthly) Wetland Methane Emissions, ERA5 LPJ-EOSIM Model v2",
                "description": "Methane emissions from wetlands in units of grams of methane per meter squared per month. ECMWF Re-Analysis (ERA5) as input to LPJ-EOSIM model.",
                "regex": ".*LPJ_EOSIM_L2_MCH4E_LL_ERA5_001.*.tif$"
            },
            "merra2-ch4-wetlands-emissions": {
                "title": "(Monthly) Wetland Methane Emissions, MERRA-2 LPJ-EOSIM Model v2",
                "description": "Methane emissions from wetlands in units of grams of methane per meter squared per month. Modern-Era Retrospective analysis for Research and Applications Version 2 (MERRA-2) data as input to LPJ-EOSIM model.",
                "regex": ".*LPJ_EOSIM_L2_MCH4E_LL_MERRA2_001.*.tif$"
            }
        },
        "id_regex": ".*_(.*).tif$",
        "id_template": "lpjeosim-wetlandch4-monthgrid-v2-{}",
        "datetime_range": "month",
        "schedule": "18 17 * * *"
    }
]

```
</details>

Created two scheduled discovery dags:
![image](https://github.com/user-attachments/assets/b8e015dd-540c-44d2-8386-5b27dea9773b)

and they worked as expected.

Existing scheduled dags with only one config also worked as expected.