### PR TITLE
Use `auth.validated_token` instead of `auth.get_username` for dataset publish endpoint

### DIFF
--- a/workflows_api/runtime/src/main.py
+++ b/workflows_api/runtime/src/main.py
@@ -76,7 +76,7 @@ def validate_dataset(dataset: schemas.COGDataset):
 
 
 @workflows_app.post(
-    "/dataset/publish", tags=["Dataset"], dependencies=[Depends(auth.get_username)]
+    "/dataset/publish", tags=["Dataset"], dependencies=[Depends(auth.validated_token)]
 )
 async def publish_dataset(
     token=Depends(auth.oauth2_scheme),


### PR DESCRIPTION
# Description

`/dataset/publish` endpoint is dependent on `auth.get_username` right now. So it expects it to be called by a programmatic client that has users with a username and a password. And it's working right now because it's mostly being called by an user with username and password. 

But when I tested publishing using a service client (that doesn't have a username and password, for example airflow), it threw an error because `auth.get_username` errors out of course. 

So this PR switches the dependency to `auth.validated_token` instead which just validates the token and doesn't care if the client is a programmatic or service client.