### PR TITLE
Check length of assume role arns

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -96,7 +96,7 @@ resource "local_file" "mwaa_variables" {
       log_group_name          = module.mwaa.log_group_name
       mwaa_execution_role_arn = module.mwaa.mwaa_role_arn
       assume_role_read_arn    = length(var.assume_role_arns) > 0 ? var.assume_role_arns[0] : ""
-      assume_role_write_arn   = length(var.assume_role_arns) > 0 ? var.assume_role_arns[0] : ""
+      assume_role_write_arn   = length(var.assume_role_arns) > 0 ? var.assume_role_arns[1] : ""
       account_id              = local.account_id
       aws_region              = local.aws_region
       cognito_app_secret      = var.workflows_client_secret

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -95,8 +95,8 @@ resource "local_file" "mwaa_variables" {
       ecs_cluster_name        = module.mwaa.cluster_name
       log_group_name          = module.mwaa.log_group_name
       mwaa_execution_role_arn = module.mwaa.mwaa_role_arn
-      assume_role_read_arn    = var.assume_role_arns[0]
-      assume_role_write_arn   = var.assume_role_arns[0]
+      assume_role_read_arn    = length(var.assume_role_arns) > 0 ? var.assume_role_arns[0] : ""
+      assume_role_write_arn   = length(var.assume_role_arns) > 0 ? var.assume_role_arns[0] : ""
       account_id              = local.account_id
       aws_region              = local.aws_region
       cognito_app_secret      = var.workflows_client_secret


### PR DESCRIPTION
In MCP environments we aren't passing assuming role arns so this PR checks if assume_role_arns is empty before passing values to `assume_role_read_arn` and `assume_role_write_arn`