### PR TITLE
Fix sh syntax error by switching to bash

### DIFF
--- a/sm2a/Makefile
+++ b/sm2a/Makefile
@@ -1,5 +1,6 @@
 SECRET_NAME=""
 ENV_FILE=".env"
+SHELL=/bin/bash
 
 important_message = \
 	@echo "\033[0;31m$(1) \033[0m"


### PR DESCRIPTION
**Summary:** Summary of changes

Switch to bash to fix the sh syntax error