### PR TITLE
Conditional vector subnets

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -109,8 +109,8 @@ resource "local_file" "mwaa_variables" {
       stac_ingestor_api_url   = var.stac_ingestor_api_url
       stac_url                = var.stac_url
       vector_secret_name      = var.vector_secret_name
-      vector_subnet_1         = length(data.aws_subnets.vector_aws_subnets.ids) > 0 ? data.aws_subnets.vector_aws_subnets.ids[0] : ""
-      vector_subnet_2         = length(data.aws_subnets.vector_aws_subnets.ids) > 0 ? data.aws_subnets.vector_aws_subnets.ids[1] : ""
+      vector_subnet_1         = length(data.aws_subnets.vector_aws_subnets.ids) > 0 ? data.aws_subnets.vector_aws_subnets.ids[0] : data.aws_subnets.subnet_ids.ids[0]
+      vector_subnet_2         = length(data.aws_subnets.vector_aws_subnets.ids) > 0 ? data.aws_subnets.vector_aws_subnets.ids[1] : data.aws_subnets.subnet_ids.ids[1]
       vector_security_group   = length(aws_security_group.vector_sg) > 0 ? aws_security_group.vector_sg[0].id : ""
       vector_vpc              = var.vector_vpc
   })


### PR DESCRIPTION
If a vector vpc is not supplied, then the vector ingest DAG will still need the mwaa private subnet. This is the case for GHG generic ingests. 