### PR TITLE
ci: remove automated deployment for staging environment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,9 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - main
       - dev
-      - production
   pull_request:
     branches:
       - main
@@ -36,12 +34,8 @@ jobs:
       - name: Set the environment based on the branch
         id: define_environment
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "env_name=staging" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
+          if [ "${{ github.ref }}" = "refs/heads/dev" ]; then
             echo "env_name=development" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/production" ]; then
-            echo "env_name=production" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"


### PR DESCRIPTION
## What
- Remove all branch-based deployment actions except for push to dev branch -> deploy dev environment
- Persist gitflow enforcer on PR
- #252 

## Why
We are deprecating MWAA but want to persist the staging environment MWAA in parallel to the new SM2A while we are cutting services over to the new system.