### PR TITLE
ci: do not automatically deploy mwaa to any environment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -65,11 +65,6 @@ jobs:
           role-session-name: "veda-airflow-github-${{ needs.define-environment.outputs.env_name }}-deployment"
           aws-region: us-west-2
 
-      - name: Run MWAA deployment
-        uses: "./.github/actions/terraform-deploy"
-        with:
-          env_aws_secret_name: ${{ secrets.ENV_AWS_SECRET_NAME }}
-
       - name: Run SM2A deployment
         # Flag to deploy SM2A
         if: ${{ vars.DEPLOY_SM2A }} = "true"


### PR DESCRIPTION
## What/why
Remove all automated MWAA deployments. We are deprecating MWAA and no longer providing backward compatibility (older versions of the project can be used to deploy MWAA as needed).