### PR TITLE
Add optional transfer step to dataset DAG

### DIFF
--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 import json
 import logging
+from copy import deepcopy
 import smart_open
 from airflow.models.variable import Variable
 from airflow.decorators import task
@@ -12,6 +13,21 @@ group_kwgs = {"group_id": "Process", "tooltip": "Process"}
 def log_task(text: str):
     logging.info(text)
 
+@task()
+def extract_discovery_items_from_payload(ti, **kwargs):
+    discovery_items = ti.dag_run.conf.get("discovery_items")
+    return discovery_items
+
+@task()
+def remove_thumbnail_asset(ti):
+    payload = deepcopy(ti.dag_run.conf)
+    assets = payload.get("assets", {})
+    if assets.get("thumbnail"):
+        assets.pop("thumbnail")
+    # if thumbnail was only asset, delete assets
+    if not assets:
+        payload.pop("assets")
+    return payload
 
 @task(retries=1, retry_delay=timedelta(minutes=1))
 def submit_to_stac_ingestor_task(built_stac: dict):

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -13,12 +13,12 @@ group_kwgs = {"group_id": "Process", "tooltip": "Process"}
 def log_task(text: str):
     logging.info(text)
 
-@task()
-def extract_discovery_items_from_payload(ti, **kwargs):
-    discovery_items = ti.dag_run.conf.get("discovery_items")
+@task
+def extract_discovery_items_from_payload(ti, payload=None, **kwargs):
+    discovery_items = ti.dag_run.conf.get("discovery_items") if not payload else payload.get("discovery_items")
     return discovery_items
 
-@task()
+@task
 def remove_thumbnail_asset(ti):
     payload = deepcopy(ti.dag_run.conf)
     assets = payload.get("assets", {})

--- a/dags/veda_data_pipeline/groups/transfer_group.py
+++ b/dags/veda_data_pipeline/groups/transfer_group.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from airflow.models.variable import Variable
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 import json

--- a/dags/veda_data_pipeline/groups/transfer_group.py
+++ b/dags/veda_data_pipeline/groups/transfer_group.py
@@ -5,6 +5,7 @@ from airflow.operators.python import BranchPythonOperator, PythonOperator
 import json
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.decorators import task
 
 group_kwgs = {"group_id": "Transfer", "tooltip": "Transfer"}
 
@@ -27,13 +28,22 @@ def cogify_copy_task(ti):
     external_role_arn = airflow_vars_json.get("ASSUME_ROLE_WRITE_ARN")
     return cogify_transfer_handler(event_src=config, external_role_arn=external_role_arn)
 
-
-def transfer_data(ti):
+@task
+def transfer_data(ti, payload):
     """Transfer data from one S3 bucket to another; s3 copy, no need for docker"""
     from veda_data_pipeline.utils.transfer import (
         data_transfer_handler,
     )
-    config = ti.dag_run.conf
+    # use task-provided payload if provided, otherwise fall back on ti values
+    # payload will generally have the same values expected by discovery, so some renames are needed when combining the dicts
+    config = {
+        **payload,
+        **ti.dag_run.conf,
+        "origin_bucket": payload.get("bucket", ti.dag_run.conf.get("origin_bucket", "veda-data-store")),
+        "origin_prefix": payload.get("prefix", ti.dag_run.conf.get("origin_prefix", "s3-prefix/")),
+        "target_bucket": payload.get("target_bucket", ti.dag_run.conf.get("target_bucket", "veda-data-store")),
+        "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", True)),# TODO default false before merge
+    }
     airflow_vars = Variable.get("aws_dags_variables")
     airflow_vars_json = json.loads(airflow_vars)
     external_role_arn = airflow_vars_json.get("ASSUME_ROLE_WRITE_ARN")

--- a/dags/veda_data_pipeline/groups/transfer_group.py
+++ b/dags/veda_data_pipeline/groups/transfer_group.py
@@ -42,7 +42,7 @@ def transfer_data(ti, payload):
         "origin_bucket": payload.get("bucket", ti.dag_run.conf.get("origin_bucket", "veda-data-store")),
         "origin_prefix": payload.get("prefix", ti.dag_run.conf.get("origin_prefix", "s3-prefix/")),
         "target_bucket": payload.get("target_bucket", ti.dag_run.conf.get("target_bucket", "veda-data-store")),
-        "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", True)),# TODO default false before merge
+        "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", False)),
     }
     airflow_vars = Variable.get("aws_dags_variables")
     airflow_vars_json = json.loads(airflow_vars)

--- a/dags/veda_data_pipeline/utils/collection_generation.py
+++ b/dags/veda_data_pipeline/utils/collection_generation.py
@@ -27,6 +27,7 @@ class GenerateCollection:
         "is_periodic",
         "time_density",
         "type",
+        "transfer"
     ]
 
     def get_template(self, dataset: Dict[str, Any]) -> dict:

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -1,7 +1,6 @@
 import pendulum
 from airflow import DAG
 from airflow.models.param import Param
-from airflow.decorators import task
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
 from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
 from veda_data_pipeline.groups.collection_group import collection_task_group
@@ -50,7 +49,7 @@ with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as d
     end = EmptyOperator(task_id="end")
 
     mutated_payloads = start >> collection_task_group() >> remove_thumbnail_asset()
-    discovery_items = extract_discovery_items_from_payload(mutated_payloads)
+    discovery_items = extract_discovery_items_from_payload(payload=mutated_payloads)
     discover = discover_from_s3_task.partial(payload=mutated_payloads).expand(event=discovery_items)
     get_files = get_files_task(payload=discover)
     build_stac = build_stac_task.expand(payload=get_files)

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -1,12 +1,11 @@
 import pendulum
 from airflow import DAG
-from copy import deepcopy
 from airflow.models.param import Param
 from airflow.decorators import task
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
 from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
 from veda_data_pipeline.groups.collection_group import collection_task_group
-from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task
+from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset
 
 template_dag_run_conf = {
     "collection": "<collection-id>",
@@ -50,29 +49,9 @@ with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as d
     start = EmptyOperator(task_id="start")
     end = EmptyOperator(task_id="end")
 
-
-    @task()
-    def remove_thumbnail_asset(ti):
-        payload = deepcopy(ti.dag_run.conf)
-        payloads = list()
-        assets = payload.get("assets", {})
-        if assets.get("thumbnail"):
-            assets.pop("thumbnail")
-        # if thumbnail was only asset, delete assets
-        if not assets:
-            payload.pop("assets")
-        for item in payload.get("discovery_items"):
-            payloads.append({
-                **payload,
-                **item
-            }
-            )
-
-        return payloads
-
-
     mutated_payloads = start >> collection_task_group() >> remove_thumbnail_asset()
-    discover = discover_from_s3_task.expand(payload=mutated_payloads)
+    discovery_items = extract_discovery_items_from_payload(mutated_payloads)
+    discover = discover_from_s3_task.partial(payload=mutated_payloads).expand(event=discovery_items)
     get_files = get_files_task(payload=discover)
     build_stac = build_stac_task.expand(payload=get_files)
     submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> end

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -120,12 +120,8 @@ with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as d
     extract_from_payload = extract_discovery_items()
 
     # asset transfer to production bucket
-    transfer_flag = dag.params.get("transfer", False)
-    if transfer_flag:
-        transfer_task = transfer_assets_to_production_bucket.expand(payload=extract_from_payload)
-        discover = discover_from_s3_task.partial(alt_payload=mutate_payload_task).expand(event=transfer_task)
-    else:
-        discover = discover_from_s3_task.partial(alt_payload=mutate_payload_task).expand(event=extract_from_payload)
+    transfer_task = transfer_assets_to_production_bucket.expand(payload=extract_from_payload)
+    discover = discover_from_s3_task.partial(alt_payload=mutate_payload_task).expand(event=transfer_task)
     discover.set_upstream(collection_grp)  # do not discover until collection exists
 
     get_files = get_dataset_files_to_process(payload=discover) # untangle mapped data format to get iterable payloads from discover step

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -1,0 +1,141 @@
+import pendulum
+from airflow import DAG
+from airflow.decorators import task
+from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
+from airflow.models.variable import Variable
+import json
+from veda_data_pipeline.groups.collection_group import collection_task_group
+from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_dataset_files_to_process
+from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task
+from veda_data_pipeline.groups.transfer_group import transfer_data
+
+
+dag_doc_md = """
+### Dataset Pipeline
+Generates a collection and triggers the file discovery process
+#### Notes
+- This DAG can run with the following configuration <br>
+```json
+{
+    "collection": "collection-id", 
+    "data_type": "cog", 
+    "description": "collection description", 
+    "discovery_items": 
+        [
+            {
+                "bucket": "veda-data-store-staging", 
+                "datetime_range": "year", 
+                "discovery": "s3", 
+                "filename_regex": "^(.*).tif$", 
+                "prefix": "example-prefix/"
+            }
+        ], 
+    "is_periodic": true, 
+    "license": "collection-LICENSE", 
+    "time_density": "year", 
+    "title": "collection-title"
+}
+```
+"""
+
+dag_args = {
+    "start_date": pendulum.today("UTC").add(days=-1),
+    "schedule_interval": None,
+    "catchup": False,
+    "doc_md": dag_doc_md,
+    "tags": ["collection", "discovery"],
+}
+
+
+@task
+def extract_discovery_items(**kwargs):
+    ti = kwargs.get("ti")
+    discovery_items = ti.dag_run.conf.get("discovery_items")
+    print(discovery_items)
+    return discovery_items
+
+
+@task(max_active_tis_per_dag=3)
+def build_stac_task(payload):
+    from veda_data_pipeline.utils.build_stac.handler import stac_handler
+    airflow_vars = Variable.get("aws_dags_variables")
+    airflow_vars_json = json.loads(airflow_vars)
+    event_bucket = airflow_vars_json.get("EVENT_BUCKET")
+    return stac_handler(payload_src=payload, bucket_output=event_bucket)
+
+@task()
+def mutate_payload(**kwargs):
+    ti = kwargs.get("ti")
+    payload = ti.dag_run.conf
+    if assets := payload.get("assets"):
+        # remove thumbnail asset if provided in collection config
+        if "thumbnail" in assets.keys():
+            assets.pop("thumbnail")
+        # if thumbnail was only asset, delete assets
+        if not assets:
+            payload.pop("assets")
+        # finally put the mutated assets back in the payload
+        else:
+            payload["assets"] = assets
+    return payload
+
+@task(max_active_tis_per_dag=3)
+def transfer_assets_to_production_bucket(payload):
+    transfer_data(payload)
+    # if transfer complete, update discovery payload to reflect new bucket
+    payload.update({"bucket": "veda-data-store"})
+    payload.update({"prefix": payload.get("collection")+"/"})
+    return payload
+
+
+template_dag_run_conf = {
+    "collection": "<collection-id>",
+    "data_type": "cog",
+    "description": "<collection-description>",
+    "discovery_items":
+        [
+            {
+                "bucket": "<bucket-name>",
+                "datetime_range": "<range>",
+                "discovery": "s3",
+                "filename_regex": "<regex>",
+                "prefix": "<example-prefix/>"
+            }
+        ],
+    "is_periodic": "<true|false>",
+    "license": "<collection-LICENSE>",
+    "time_density": "<time-density>",
+    "title": "<collection-title>",
+    "transfer": "<true|false> # transfer assets to production bucket if true (false by default)", 
+}
+
+with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as dag:
+    # ECS dependency variable
+
+    start = EmptyOperator(task_id="start", dag=dag)
+    end = EmptyOperator(task_id="end", dag=dag)
+
+    collection_grp = collection_task_group()
+    mutate_payload_task = mutate_payload()
+    extract_from_payload = extract_discovery_items()
+
+    # asset transfer to production bucket
+    transfer_flag = dag.params.get("transfer", False)
+    if transfer_flag:
+        transfer_task = transfer_assets_to_production_bucket.expand(payload=extract_from_payload)
+        discover = discover_from_s3_task.partial(alt_payload=mutate_payload_task).expand(event=transfer_task)
+    else:
+        discover = discover_from_s3_task.partial(alt_payload=mutate_payload_task).expand(event=extract_from_payload)
+    discover.set_upstream(collection_grp)  # do not discover until collection exists
+
+    get_files = get_dataset_files_to_process(payload=discover) # untangle mapped data format to get iterable payloads from discover step
+
+    
+    build_stac = build_stac_task.expand(payload=get_files)
+    build_stac.set_upstream(get_files)
+    # .output is needed coming from a non-taskflow operator
+    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac)
+
+    collection_grp.set_upstream(start)
+    mutate_payload_task.set_upstream(start)
+    submit_stac.set_downstream(end)

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -6,13 +6,14 @@ from airflow.models.variable import Variable
 import json
 from veda_data_pipeline.groups.collection_group import collection_task_group
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_dataset_files_to_process
-from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task
+from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset
 from veda_data_pipeline.groups.transfer_group import transfer_data
 
-
 dag_doc_md = """
-### Dataset Pipeline
-Generates a collection and triggers the file discovery process
+### Promotion Pipeline
+Generates a collection and triggers the file discovery process.
+This DAG uses the same input ad `veda-dataset-pipeline` but adds the ability to transfer assets to the production bucket.
+This will mutate the payload, so that item references will target the new asset locations.
 #### Notes
 - This DAG can run with the following configuration <br>
 ```json
@@ -46,48 +47,6 @@ dag_args = {
     "tags": ["collection", "discovery"],
 }
 
-
-@task
-def extract_discovery_items(**kwargs):
-    ti = kwargs.get("ti")
-    discovery_items = ti.dag_run.conf.get("discovery_items")
-    print(discovery_items)
-    return discovery_items
-
-
-@task(max_active_tis_per_dag=3)
-def build_stac_task(payload):
-    from veda_data_pipeline.utils.build_stac.handler import stac_handler
-    airflow_vars = Variable.get("aws_dags_variables")
-    airflow_vars_json = json.loads(airflow_vars)
-    event_bucket = airflow_vars_json.get("EVENT_BUCKET")
-    return stac_handler(payload_src=payload, bucket_output=event_bucket)
-
-@task()
-def mutate_payload(**kwargs):
-    ti = kwargs.get("ti")
-    payload = ti.dag_run.conf
-    if assets := payload.get("assets"):
-        # remove thumbnail asset if provided in collection config
-        if "thumbnail" in assets.keys():
-            assets.pop("thumbnail")
-        # if thumbnail was only asset, delete assets
-        if not assets:
-            payload.pop("assets")
-        # finally put the mutated assets back in the payload
-        else:
-            payload["assets"] = assets
-    return payload
-
-@task(max_active_tis_per_dag=3)
-def transfer_assets_to_production_bucket(payload):
-    transfer_data(payload)
-    # if transfer complete, update discovery payload to reflect new bucket
-    payload.update({"bucket": "veda-data-store"})
-    payload.update({"prefix": payload.get("collection")+"/"})
-    return payload
-
-
 template_dag_run_conf = {
     "collection": "<collection-id>",
     "data_type": "cog",
@@ -109,27 +68,31 @@ template_dag_run_conf = {
     "transfer": "<true|false> # transfer assets to production bucket if true (false by default)", 
 }
 
-with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as dag:
+@task(max_active_tis_per_dag=3)
+def transfer_assets_to_production_bucket(payload):
+    transfer_data(payload)
+    # if transfer complete, update discovery payload to reflect new bucket
+    payload.update({"bucket": "veda-data-store"})
+    payload.update({"prefix": payload.get("collection")+"/"})
+    return payload
+
+with DAG("veda_promotion_pipeline", params=template_dag_run_conf, **dag_args) as dag:
     # ECS dependency variable
 
     start = EmptyOperator(task_id="start", dag=dag)
     end = EmptyOperator(task_id="end", dag=dag)
 
     collection_grp = collection_task_group()
-    mutate_payload_task = mutate_payload()
-    extract_from_payload = extract_discovery_items()
+    mutate_payload_task = remove_thumbnail_asset()
+    extract_from_payload = extract_discovery_items_from_payload()
 
     # asset transfer to production bucket
     transfer_task = transfer_assets_to_production_bucket.expand(payload=extract_from_payload)
-    discover = discover_from_s3_task.partial(alt_payload=mutate_payload_task).expand(event=transfer_task)
+    discover = discover_from_s3_task.partial(payload=mutate_payload_task).expand(event=transfer_task)
     discover.set_upstream(collection_grp)  # do not discover until collection exists
 
     get_files = get_dataset_files_to_process(payload=discover) # untangle mapped data format to get iterable payloads from discover step
-
-    
     build_stac = build_stac_task.expand(payload=get_files)
-    build_stac.set_upstream(get_files)
-    # .output is needed coming from a non-taskflow operator
     submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac)
 
     collection_grp.set_upstream(start)

--- a/sm2a/Makefile
+++ b/sm2a/Makefile
@@ -10,8 +10,8 @@ info_message = \
 
 count_down = \
 	@echo "Spinning up the system please wait..."; \
-	secs=40; \
-	while [ $secs -gt 0 ]; do \
+	secs=40 ;\
+	while [ $$secs -gt 0 ]; do \
 		printf "%d\033[0K\r" "$$secs"; \
 		sleep 1; \
 		secs=$$((secs - 1)); \
@@ -26,6 +26,9 @@ all: sm2a-local-init sm2a-local-run
 
 refresh: sm2a-local-build sm2a-local-run
 
+count_down_test:
+	$(count_down)
+
 sm2a-local-run: sm2a-local-stop
 	@echo "Running SM2A"
 	docker compose up -d
@@ -36,7 +39,6 @@ sm2a-local-run: sm2a-local-stop
 	@echo "To use local SM2A with AWS update ${SM2A_FOLDER}/sm2a-local-config/.env AWS credentials"
 
 sm2a-local-init:
-	cp sm2a-local-config/env_example sm2a-local-config/.env
 	cp -r ../dags .
 	docker compose run --rm airflow-cli db init
 	docker compose run --rm airflow-cli users create --email airflow@example.com --firstname airflow --lastname airflow --password airflow --username airflow --role Admin

--- a/sm2a/Makefile
+++ b/sm2a/Makefile
@@ -12,9 +12,9 @@ count_down = \
 	@echo "Spinning up the system please wait..."; \
 	secs=40; \
 	while [ $secs -gt 0 ]; do \
-		printf "%d\033[0K\r" "$secs"; \
+		printf "%d\033[0K\r" "$$secs"; \
 		sleep 1; \
-		((secs--)); \
+		secs=$$((secs - 1)); \
 	done;
 
 .PHONY:

--- a/sm2a/Makefile
+++ b/sm2a/Makefile
@@ -12,7 +12,7 @@ count_down = \
 	@echo "Spinning up the system please wait..."; \
 	secs=40; \
 	while [ $secs -gt 0 ]; do \
-		printf "%d\033[0K\r" $secs; \
+		printf "%d\033[0K\r" "$secs"; \
 		sleep 1; \
 		((secs--)); \
 	done;
@@ -23,6 +23,8 @@ count_down = \
 	list
 
 all: sm2a-local-init sm2a-local-run
+
+refresh: sm2a-local-build sm2a-local-run
 
 sm2a-local-run: sm2a-local-stop
 	@echo "Running SM2A"

--- a/sm2a/Makefile
+++ b/sm2a/Makefile
@@ -10,11 +10,11 @@ info_message = \
 
 count_down = \
 	@echo "Spinning up the system please wait..."; \
-	secs=40 ;\
-	while [ $$secs -gt 0 ]; do \
-		printf "%d\033[0K\r" $$secs; \
+	secs=40; \
+	while [ $secs -gt 0 ]; do \
+		printf "%d\033[0K\r" $secs; \
 		sleep 1; \
-		: $$((secs--)); \
+		((secs--)); \
 	done;
 
 .PHONY:


### PR DESCRIPTION
Addresses #256 

If `transfer: true` is included in the dataset DAG payload, assets will be transferred to the production bucket prior to discovery and STAC item creation. 

`dry_run` is set to True by default - this should be changed before merging, but is better for testing.