### PR TITLE
fix: remove pypgstac install

### DIFF
--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -11,7 +11,6 @@ apache-airflow-providers-postgres==5.2.2
 apache-airflow-providers-common-sql==1.2.0
 typing-extensions==4.4.0
 psycopg2-binary==2.9.5
-pypgstac==0.7.4
 pyOpenSSL==22.0.0
 stac-pydantic
 fsspec

--- a/sm2a/airflow_worker/Dockerfile
+++ b/sm2a/airflow_worker/Dockerfile
@@ -41,8 +41,6 @@ COPY --chown=airflow:airflow scripts "${AIRFLOW_HOME}/scripts"
 
 RUN cp ${AIRFLOW_HOME}/configuration/airflow.cfg* ${AIRFLOW_HOME}/.
 
-RUN pip install pypgstac==0.7.4
-
 # ENV
 ENV AIRFLOW_HOME ${AIRFLOW_HOME}
 ENV TZ UTC


### PR DESCRIPTION
## What
- Remove unused pypgstac install from airflow worker
- Remove unused pypgstac requirement for dags

## Why
- pypgstac is managed by veda backend/ingest-api 
- this unused pypgstac install also causes a breaking pydantic version downgrade