### PR TITLE
fix: remove python version dependent datetime formatter in collection generation

### DIFF
--- a/dags/veda_data_pipeline/utils/collection_generation.py
+++ b/dags/veda_data_pipeline/utils/collection_generation.py
@@ -102,9 +102,8 @@ class GenerateCollection:
         if temporal_extent := dataset.get("temporal_extent"):
             collection_stac["extent"]["temporal"] = {
                 "interval": [
-                    # most of our data uses the Z suffix for UTC - isoformat() doesn't
                     [
-                        datetime.fromisoformat(x).astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+                        x
                         if x else None
                         for x in list(temporal_extent.values())
                     ]


### PR DESCRIPTION
## What
Remove python version dependent datetime formatter in collection generation. The ingest API validates the datetime format and the helper method in the collection DAG fails for python versions <3.11.