### PR TITLE
fix(submit-stac): modify retry behavior for API submission

### DIFF
--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -29,7 +29,8 @@ def remove_thumbnail_asset(ti):
         payload.pop("assets")
     return payload
 
-@task(retries=1, retry_delay=timedelta(minutes=1))
+# with exponential backoff enabled, retry delay is converted to seconds
+@task(retries=2, retry_delay=60, retry_exponential_backoff=True, max_active_tis_per_dag=5)
 def submit_to_stac_ingestor_task(built_stac: dict):
     """Submit STAC items to the STAC ingestor API."""
     event = built_stac.copy()


### PR DESCRIPTION
Adding some new behaviour to the submit-stac step, which was having intermittent failures at high concurrency (400+ concurrent tasks). 

Lots of room to tune this, but this gets things moving for now (also, the problematic ingest takes 40 minutes to complete, with or without errors). It's unclear whether the original issue was originating from ECS memory limits (causing OOM errors to kill/zombie-fy tasks) or API throughput limitations (causing timeouts to kill tasks). These changes will solve both, but to maximize ingest throughput, we should figure out a way to monitor both sets of metrics and adjust these parameters as needed.