### PR TITLE
fix(build_stac): Use airflow vars instead of env var for build stac role

### DIFF
--- a/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
+++ b/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
@@ -4,6 +4,7 @@ import pystac
 import rasterio
 from pystac.utils import datetime_to_str
 from rasterio.session import AWSSession
+from airflow.models.variable import Variable
 from rio_stac import stac
 from rio_stac.stac import PROJECTION_EXT_VERSION, RASTER_EXT_VERSION
 

--- a/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
+++ b/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
@@ -14,7 +14,7 @@ from . import events, regex, role
 def get_sts_session():
     airflow_vars = Variable.get("aws_dags_variables")
     airflow_vars_json = json.loads(airflow_vars)
-    if external_role_arn := airflow_vars_json.get("ASSUME_ROLE_READ_ARN")
+    if external_role_arn := airflow_vars_json.get("ASSUME_ROLE_READ_ARN"):
         creds = role.assume_role(external_role_arn, "veda-data-pipelines_build-stac")
         return AWSSession(
             aws_access_key_id=creds["AccessKeyId"],

--- a/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
+++ b/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
@@ -1,4 +1,4 @@
-import os
+import json
 
 import pystac
 import rasterio
@@ -12,8 +12,10 @@ from . import events, regex, role
 
 
 def get_sts_session():
-    if role_arn := os.environ.get("EXTERNAL_ROLE_ARN"):
-        creds = role.assume_role(role_arn, "veda-data-pipelines_build-stac")
+    airflow_vars = Variable.get("aws_dags_variables")
+    airflow_vars_json = json.loads(airflow_vars)
+    if external_role_arn := airflow_vars_json.get("ASSUME_ROLE_READ_ARN")
+        creds = role.assume_role(external_role_arn, "veda-data-pipelines_build-stac")
         return AWSSession(
             aws_access_key_id=creds["AccessKeyId"],
             aws_secret_access_key=creds["SecretAccessKey"],


### PR DESCRIPTION
Fix for https://github.com/NASA-IMPACT/veda-data-airflow/issues/280

Tested in dev: https://sm2a.dev.openveda.cloud/dags/veda_promotion_pipeline/grid?dag_run_id=manual__2025-01-10T21%3A05%3A57%2B00%3A00