### PR TITLE
fix(dag): resolve rio-stac dag import error

### DIFF
--- a/sm2a/airflow_services/requirements.txt
+++ b/sm2a/airflow_services/requirements.txt
@@ -15,6 +15,7 @@ affine
 netCDF4
 requests
 rio-cogeo
+rio-stac
 smart-open
 apache-airflow-providers-common-sql
 typing-extensions


### PR DESCRIPTION
## What
Attempt to resolve DAG import errors by adding worker requirement to service requirements.

## Related issue
#282 