### PR TITLE
fix: Add .airflowignore

### DIFF
--- a/dags/.airflowignore
+++ b/dags/.airflowignore
@@ -1,0 +1,3 @@
+# Ignore files which do not define DAGs
+groups
+utils


### PR DESCRIPTION
**Summary:** Summary of changes

Fix for https://github.com/NASA-IMPACT/veda-data-airflow/issues/282

The DAG processor will pick up and try to process any .py files containing the string "dag" outside of a comment. We only need the processor to handle files that actually define a DAG.