### PR TITLE
fix: Updates to fail gracefully if there are no assets to resolve key_error

### DIFF
--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -25,8 +25,9 @@ def remove_thumbnail_asset(ti):
     if assets.get("thumbnail"):
         assets.pop("thumbnail")
     # if thumbnail was only asset, delete assets
-    if not assets and (assets is not None):
-        payload.pop("assets")
+    if not assets:
+        # Safely return if there are no assets in the payload
+        payload.pop("assets", True)
     return payload
 
 # with exponential backoff enabled, retry delay is converted to seconds

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -25,7 +25,7 @@ def remove_thumbnail_asset(ti):
     if assets.get("thumbnail"):
         assets.pop("thumbnail")
     # if thumbnail was only asset, delete assets
-    if not assets:
+    if not assets and (assets is not None):
         payload.pop("assets")
     return payload
 


### PR DESCRIPTION
**Summary:** Summary of changes
Addresses [VEDA-287: Resolve Key error in veda_dataset_pipeline](https://github.com/NASA-IMPACT/veda-data-airflow/issues/287)

## Changes

* Updates to fail gracefully if there are no assets for  `payload.pop("assets")`

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests