### PR TITLE
Submit STAC using transactions API

### DIFF
--- a/dags/veda_data_pipeline/groups/collection_group.py
+++ b/dags/veda_data_pipeline/groups/collection_group.py
@@ -44,7 +44,7 @@ def ingest_collection_task(ti=None, collection=None):
         event=collection,
         endpoint="/collections",
         cognito_app_secret=cognito_app_secret,
-        stac_ingestor_api_url=stac_ingestor_api_url
+        ingest_url=stac_ingestor_api_url
     )
 
 

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -51,7 +51,6 @@ def submit_to_stac_ingestor_task(built_stac: dict):
     """Submit STAC items to the STAC ingestor API."""
     event = built_stac.copy()
     success_file = event["payload"]["success_event_key"]
-
     try:
         success_file = event["payload"]["success_event_key"]
         with smart_open.open(success_file, "r") as _file:

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -37,14 +37,12 @@ if TRANSACTIONS_ENDPOINT_ENABLED:
     # assuming default chunk size (500), this matches the current dynamoDB configuration on the STAC ingestor
     task_kwargs = {"retries": 3, "retry_delay": 10, "retry_exponential_backoff": True, "max_active_tis_per_dag": 2}
     submit_kwargs = {}
-    submit_handler = submit_transactions_handler
-    ingest_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
+    ingest_url = airflow_vars_json.get("STAC_URL")
     app_secret = airflow_vars_json.get("STAC_API_KEYCLOAK_CLIENT_SECRET")
 else:
     task_kwargs = {"retries": 2, "retry_delay": 60, "retry_exponential_backoff": True, "max_active_tis_per_dag": 5}
     submit_kwargs = {"endpoint": "/ingestions"}
-    submit_handler = submission_handler
-    ingest_url = airflow_vars_json.get("STAC_URL")
+    ingest_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
     app_secret = airflow_vars_json.get("COGNITO_APP_SECRET")
 
 # with exponential backoff enabled, retry delay is converted to seconds
@@ -62,13 +60,21 @@ def submit_to_stac_ingestor_task(built_stac: dict):
         log_task("No success file found - using event directly")
         stac_items = [event]
 
-    for item in stac_items:
-        submit_handler(
-            event=item,
+    if TRANSACTIONS_ENDPOINT_ENABLED:
+        submit_transactions_handler(
+            event=stac_items,
             cognito_app_secret=app_secret,
             ingest_url=ingest_url,
             **submit_kwargs,
         )
+    else:
+        for item in stac_items:
+            submission_handler(
+                event=item,
+                cognito_app_secret=app_secret,
+                ingest_url=ingest_url,
+                **submit_kwargs,
+            )
     return event
 
 @task(retries=2, retry_delay=60, retry_exponential_backoff=True, max_active_tis_per_dag=5)

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -39,11 +39,13 @@ if TRANSACTIONS_ENDPOINT_ENABLED:
     submit_kwargs = {}
     submit_handler = submit_transactions_handler
     ingest_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
+    app_secret = airflow_vars_json.get("STAC_API_KEYCLOAK_CLIENT_SECRET")
 else:
     task_kwargs = {"retries": 2, "retry_delay": 60, "retry_exponential_backoff": True, "max_active_tis_per_dag": 5}
     submit_kwargs = {"endpoint": "/ingestions"}
     submit_handler = submission_handler
     ingest_url = airflow_vars_json.get("STAC_URL")
+    app_secret = airflow_vars_json.get("COGNITO_APP_SECRET")
 
 # with exponential backoff enabled, retry delay is converted to seconds
 @task(**task_kwargs)
@@ -52,9 +54,6 @@ def submit_to_stac_ingestor_task(built_stac: dict):
     event = built_stac.copy()
     success_file = event["payload"]["success_event_key"]
 
-    airflow_vars = Variable.get("aws_dags_variables")
-    airflow_vars_json = json.loads(airflow_vars)
-    cognito_app_secret = airflow_vars_json.get("COGNITO_APP_SECRET")
     try:
         success_file = event["payload"]["success_event_key"]
         with smart_open.open(success_file, "r") as _file:
@@ -66,7 +65,7 @@ def submit_to_stac_ingestor_task(built_stac: dict):
     for item in stac_items:
         submit_handler(
             event=item,
-            cognito_app_secret=cognito_app_secret,
+            cognito_app_secret=app_secret,
             ingest_url=ingest_url,
             **submit_kwargs,
         )

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -38,10 +38,12 @@ if TRANSACTIONS_ENDPOINT_ENABLED:
     task_kwargs = {"retries": 3, "retry_delay": 10, "retry_exponential_backoff": True, "max_active_tis_per_dag": 2}
     submit_kwargs = {}
     submit_handler = submit_transactions_handler
+    ingest_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
 else:
     task_kwargs = {"retries": 2, "retry_delay": 60, "retry_exponential_backoff": True, "max_active_tis_per_dag": 5}
     submit_kwargs = {"endpoint": "/ingestions"}
     submit_handler = submission_handler
+    ingest_url = airflow_vars_json.get("STAC_URL")
 
 # with exponential backoff enabled, retry delay is converted to seconds
 @task(**task_kwargs)
@@ -53,7 +55,6 @@ def submit_to_stac_ingestor_task(built_stac: dict):
     airflow_vars = Variable.get("aws_dags_variables")
     airflow_vars_json = json.loads(airflow_vars)
     cognito_app_secret = airflow_vars_json.get("COGNITO_APP_SECRET")
-    stac_ingestor_api_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
     try:
         success_file = event["payload"]["success_event_key"]
         with smart_open.open(success_file, "r") as _file:
@@ -66,7 +67,7 @@ def submit_to_stac_ingestor_task(built_stac: dict):
         submit_handler(
             event=item,
             cognito_app_secret=cognito_app_secret,
-            stac_ingestor_api_url=stac_ingestor_api_url,
+            ingest_url=ingest_url,
             **submit_kwargs,
         )
     return event

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 import json
 import logging
 from copy import deepcopy
@@ -10,6 +9,9 @@ from veda_data_pipeline.utils.submit_stac_transactions import submit_transaction
 
 group_kwgs = {"group_id": "Process", "tooltip": "Process"}
 
+airflow_vars = Variable.get("aws_dags_variables")
+airflow_vars_json = json.loads(airflow_vars)
+TRANSACTIONS_ENDPOINT_ENABLED = airflow_vars_json.get("TRANSACTIONS_ENDPOINT_ENABLED", False)
 
 def log_task(text: str):
     logging.info(text)
@@ -31,13 +33,14 @@ def remove_thumbnail_asset(ti):
         payload.pop("assets", True)
     return payload
 
-TRANSACTIONS_ENDPOINT_ENABLED = False
 if TRANSACTIONS_ENDPOINT_ENABLED:
-    # assuming default chunk size, this matches the current dynamoDB configuration on the STAC ingestor
+    # assuming default chunk size (500), this matches the current dynamoDB configuration on the STAC ingestor
     task_kwargs = {"retries": 3, "retry_delay": 10, "retry_exponential_backoff": True, "max_active_tis_per_dag": 2}
+    submit_kwargs = {}
     submit_handler = submit_transactions_handler
 else:
     task_kwargs = {"retries": 2, "retry_delay": 60, "retry_exponential_backoff": True, "max_active_tis_per_dag": 5}
+    submit_kwargs = {"endpoint": "/ingestions"}
     submit_handler = submission_handler
 
 # with exponential backoff enabled, retry delay is converted to seconds
@@ -62,9 +65,9 @@ def submit_to_stac_ingestor_task(built_stac: dict):
     for item in stac_items:
         submit_handler(
             event=item,
-            endpoint="/ingestions",
             cognito_app_secret=cognito_app_secret,
             stac_ingestor_api_url=stac_ingestor_api_url,
+            **submit_kwargs,
         )
     return event
 

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -6,6 +6,7 @@ import smart_open
 from airflow.models.variable import Variable
 from airflow.decorators import task
 from veda_data_pipeline.utils.submit_stac import submission_handler
+from veda_data_pipeline.utils.submit_stac_transactions import submit_transactions_handler
 
 group_kwgs = {"group_id": "Process", "tooltip": "Process"}
 
@@ -30,8 +31,17 @@ def remove_thumbnail_asset(ti):
         payload.pop("assets", True)
     return payload
 
+TRANSACTIONS_ENDPOINT_ENABLED = False
+if TRANSACTIONS_ENDPOINT_ENABLED:
+    # assuming default chunk size, this matches the current dynamoDB configuration on the STAC ingestor
+    task_kwargs = {"retries": 3, "retry_delay": 10, "retry_exponential_backoff": True, "max_active_tis_per_dag": 2}
+    submit_handler = submit_transactions_handler
+else:
+    task_kwargs = {"retries": 2, "retry_delay": 60, "retry_exponential_backoff": True, "max_active_tis_per_dag": 5}
+    submit_handler = submission_handler
+
 # with exponential backoff enabled, retry delay is converted to seconds
-@task(retries=2, retry_delay=60, retry_exponential_backoff=True, max_active_tis_per_dag=5)
+@task(**task_kwargs)
 def submit_to_stac_ingestor_task(built_stac: dict):
     """Submit STAC items to the STAC ingestor API."""
     event = built_stac.copy()
@@ -50,7 +60,7 @@ def submit_to_stac_ingestor_task(built_stac: dict):
         stac_items = [event]
 
     for item in stac_items:
-        submission_handler(
+        submit_handler(
             event=item,
             endpoint="/ingestions",
             cognito_app_secret=cognito_app_secret,

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -39,17 +39,19 @@ if TRANSACTIONS_ENDPOINT_ENABLED:
     submit_kwargs = {}
     ingest_url = airflow_vars_json.get("STAC_URL")
     app_secret = airflow_vars_json.get("STAC_API_KEYCLOAK_CLIENT_SECRET")
+    submit_handler = submit_transactions_handler
 else:
     task_kwargs = {"retries": 2, "retry_delay": 60, "retry_exponential_backoff": True, "max_active_tis_per_dag": 5}
     submit_kwargs = {"endpoint": "/ingestions"}
     ingest_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
     app_secret = airflow_vars_json.get("COGNITO_APP_SECRET")
+    submit_handler = submission_handler
 
 # with exponential backoff enabled, retry delay is converted to seconds
 @task(**task_kwargs)
 def submit_to_stac_ingestor_task(built_stac: dict):
     """Submit STAC items to the STAC ingestor API."""
-    event = built_stac.copy()
+    event = built_stac.copy()   
     try:
         success_file = event["payload"]["success_event_key"]
         with smart_open.open(success_file, "r") as _file:
@@ -58,21 +60,14 @@ def submit_to_stac_ingestor_task(built_stac: dict):
         log_task("No success file found - using event directly")
         stac_items = [event]
 
-    if TRANSACTIONS_ENDPOINT_ENABLED:
-        submit_transactions_handler(
-            event=stac_items,
+    for item in stac_items:
+        submit_handler(
+            event=item,
             cognito_app_secret=app_secret,
             ingest_url=ingest_url,
             **submit_kwargs,
         )
-    else:
-        for item in stac_items:
-            submission_handler(
-                event=item,
-                cognito_app_secret=app_secret,
-                ingest_url=ingest_url,
-                **submit_kwargs,
-            )
+
     return event
 
 @task(retries=2, retry_delay=60, retry_exponential_backoff=True, max_active_tis_per_dag=5)

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -50,7 +50,6 @@ else:
 def submit_to_stac_ingestor_task(built_stac: dict):
     """Submit STAC items to the STAC ingestor API."""
     event = built_stac.copy()
-    success_file = event["payload"]["success_event_key"]
     try:
         success_file = event["payload"]["success_event_key"]
         with smart_open.open(success_file, "r") as _file:

--- a/dags/veda_data_pipeline/utils/submit_stac.py
+++ b/dags/veda_data_pipeline/utils/submit_stac.py
@@ -102,10 +102,7 @@ def submission_handler(
     endpoint: str = "/ingestions",
     cognito_app_secret=None,
     stac_ingestor_api_url=None,
-    context=None,
 ) -> None | dict:
-    if context is None:
-        context = {}
 
     stac_item = event
 

--- a/dags/veda_data_pipeline/utils/submit_stac.py
+++ b/dags/veda_data_pipeline/utils/submit_stac.py
@@ -101,7 +101,7 @@ def submission_handler(
     event: Union[S3LinkInput, StacItemInput, Dict[str, Any]],
     endpoint: str = "/ingestions",
     cognito_app_secret=None,
-    stac_ingestor_api_url=None,
+    ingest_url=None,
 ) -> None | dict:
 
     stac_item = event
@@ -111,12 +111,9 @@ def submission_handler(
         print(json.dumps(stac_item, indent=2))
         return
 
-    cognito_app_secret = cognito_app_secret or os.getenv("COGNITO_APP_SECRET")
-    stac_ingestor_api_url = stac_ingestor_api_url or os.getenv("STAC_INGESTOR_API_URL")
-
     ingestor = IngestionApi.from_veda_auth_secret(
         secret_id=cognito_app_secret,
-        base_url=stac_ingestor_api_url,
+        base_url=ingest_url,
     )
     return ingestor.submit(event=stac_item, endpoint=endpoint)
 

--- a/dags/veda_data_pipeline/utils/submit_stac_transactions.py
+++ b/dags/veda_data_pipeline/utils/submit_stac_transactions.py
@@ -21,7 +21,7 @@ class AppConfig(TypedDict):
 class TransactionsApi:
 
     @classmethod
-    def from_veda_auth_secret(cls, *, secret_id: str, base_url: str) -> "IngestionApi":
+    def from_veda_auth_secret(cls, *, secret_id: str, base_url: str) -> "TransactionsApi":
         cognito_details = cls._get_cognito_service_details(secret_id)
         credentials = cls._get_app_credentials(**cognito_details)
         return cls(token=credentials["access_token"], base_url=base_url)
@@ -52,16 +52,15 @@ class TransactionsApi:
             response.raise_for_status()
         except Exception as ex:
             print(response.text)
-            raise f"Error, {ex}"
+            raise RuntimeError(f"Error, {ex}")
         return response.json()
 
-    def __init__(self, stac_ingestor_api_url: str, cognito_app_secret: str = None):
+    def __init__(self, stac_ingestor_api_url: str):
         """
         :param stac_endpoint: Base URL of the STAC API (e.g., 'https://example.com/stac').
         :param token: Optional Bearer token for authenticated STAC APIs.
         """
         self.stac_ingestor_api_url = stac_ingestor_api_url.rstrip('/')
-        self.cognito_app_secret = cognito_app_secret
 
     def post_items(self, collection_id: str, items: List[dict]) -> dict:
         """
@@ -91,7 +90,7 @@ class TransactionsApi:
 
 def submit_transactions_handler(
         event, 
-        cognito_app_secret=None,
+        cognito_app_secret=None, # unused, but maintains signature compatibility w/ ingest API
         stac_ingestor_api_url=None,
     ):
     """
@@ -105,7 +104,7 @@ def submit_transactions_handler(
     """
 
     collection_id = event[0].get("collection")
-    api = TransactionsApi(stac_ingestor_api_url, cognito_app_secret)
+    api = TransactionsApi(stac_ingestor_api_url)
     try:
         response = api.post_items(collection_id, event)
         logging.info("STAC Item POST completed successfully.")

--- a/dags/veda_data_pipeline/utils/submit_stac_transactions.py
+++ b/dags/veda_data_pipeline/utils/submit_stac_transactions.py
@@ -19,6 +19,8 @@ class AppConfig(TypedDict):
     scope: str
 
 class TransactionsApi:
+    base_url: str
+    token: str
 
     @classmethod
     def from_veda_auth_secret(cls, *, secret_id: str, base_url: str) -> "TransactionsApi":
@@ -55,14 +57,8 @@ class TransactionsApi:
             raise RuntimeError(f"Error, {ex}")
         return response.json()
 
-    def __init__(self, stac_ingestor_api_url: str):
-        """
-        :param stac_endpoint: Base URL of the STAC API (e.g., 'https://example.com/stac').
-        :param token: Optional Bearer token for authenticated STAC APIs.
-        """
-        self.stac_ingestor_api_url = stac_ingestor_api_url.rstrip('/')
 
-    def post_items(self, collection_id: str, items: List[dict]) -> dict:
+    def post_items(self, collection_id: str, items: List[dict], endpoint: str) -> dict:
         """
         Perform a PUT request to update or create a STAC Item in the given collection.
 
@@ -72,14 +68,16 @@ class TransactionsApi:
         :return: The JSON response (as a dict) from the STAC API.
         :raises RuntimeError: If the response is not 200/201.
         """
-        url = f"{self.base_url.rstrip('/')}{self.stac_ingestor_api_url}/collections/{collection_id}/bulk_items"
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
 
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-
-        logging.info(f"PUT {url}")
-        response = requests.post(url, headers=headers, json=items)
+        response = requests.post(
+            f"{self.base_url.rstrip('/')}{endpoint}", 
+            headers=headers, 
+            json=items
+        )
 
         if response.status_code not in (200, 201):
             logging.error("Failed PUT request: %s %s", response.status_code, response.text)
@@ -91,7 +89,8 @@ class TransactionsApi:
 def submit_transactions_handler(
         event, 
         cognito_app_secret=None, # unused, but maintains signature compatibility w/ ingest API
-        stac_ingestor_api_url=None,
+        ingest_url=None,
+        endpoint="/collections/{collection_id}/bulk_items"
     ):
     """
     Handler function that can be integrated in the same way as the existing `submission_handler`,
@@ -104,10 +103,17 @@ def submit_transactions_handler(
     """
 
     collection_id = event[0].get("collection")
-    api = TransactionsApi(stac_ingestor_api_url)
+    api = TransactionsApi.from_veda_auth_secret(
+        secret_id=cognito_app_secret,
+        base_url=ingest_url,
+    )
     try:
-        response = api.post_items(collection_id, event)
-        logging.info("STAC Item POST completed successfully.")
+        response = api.post_items(
+            collection_id=collection_id, 
+            items=event,
+            endpoint=endpoint
+        )
+        logging.info("STAC Bulk Item POST completed successfully.")
     except RuntimeError as err:
         logging.error("Error while performing POST: %s", str(err))
         raise

--- a/dags/veda_data_pipeline/utils/submit_stac_transactions.py
+++ b/dags/veda_data_pipeline/utils/submit_stac_transactions.py
@@ -11,12 +11,14 @@ class Creds(TypedDict):
     access_token: str
     expires_in: int
     token_type: str
-
-class AppConfig(TypedDict):
-    cognito_domain: str
-    client_id: str
-    client_secret: str
     scope: str
+
+class Secret(TypedDict):
+    userinfo_url: str
+    id: str
+    secret: str
+    auth_url: str
+    token_url: str
 
 class TransactionsApi:
     base_url: str
@@ -24,30 +26,31 @@ class TransactionsApi:
 
     @classmethod
     def from_veda_auth_secret(cls, *, secret_id: str, base_url: str) -> "TransactionsApi":
-        cognito_details = cls._get_cognito_service_details(secret_id)
-        credentials = cls._get_app_credentials(**cognito_details)
+        secret_details = cls._get_auth_service_details(secret_id)
+        credentials = cls._get_app_credentials(**secret_details)
         return cls(token=credentials["access_token"], base_url=base_url)
 
     @staticmethod
-    def _get_cognito_service_details(secret_id: str) -> AppConfig:
+    def _get_auth_service_details(secret_id: str) -> Secret:
         client = boto3.client("secretsmanager")
         response = client.get_secret_value(SecretId=secret_id)
         return json.loads(response["SecretString"])
 
     @staticmethod
     def _get_app_credentials(
-        cognito_domain: str, client_id: str, client_secret: str, scope: str, **kwargs
+        userinfo_url: str, id: str, secret: str, auth_url: str, token_url: str, **kwargs
     ) -> Creds:
         response = requests.post(
-            f"{cognito_domain}/oauth2/token",
+            token_url,
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json"
             },
-            auth=(client_id, client_secret),
             data={
+                "client_id": id,
+                "client_secret": secret,
                 "grant_type": "client_credentials",
-                # A space-separated list of scopes to request for the generated access token.
-                "scope": scope,
+                "scopes": "stac:item:create stac:collection:create"
             },
         )
         try:
@@ -72,11 +75,11 @@ class TransactionsApi:
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
         }
-
+        bulk_items = {"items": {item['id']: item for item in items}, "method": "upsert"}
         response = requests.post(
-            f"{self.base_url.rstrip('/')}{endpoint}", 
+            f"{self.base_url.rstrip('/')}/collections/{collection_id}/bulk_items", 
             headers=headers, 
-            json=items
+            json=bulk_items
         )
 
         if response.status_code not in (200, 201):
@@ -89,8 +92,7 @@ class TransactionsApi:
 def submit_transactions_handler(
         event, 
         cognito_app_secret=None, # unused, but maintains signature compatibility w/ ingest API
-        ingest_url=None,
-        endpoint="/collections/{collection_id}/bulk_items"
+        ingest_url=None
     ):
     """
     Handler function that can be integrated in the same way as the existing `submission_handler`,
@@ -111,7 +113,6 @@ def submit_transactions_handler(
         response = api.post_items(
             collection_id=collection_id, 
             items=event,
-            endpoint=endpoint
         )
         logging.info("STAC Bulk Item POST completed successfully.")
     except RuntimeError as err:

--- a/dags/veda_data_pipeline/utils/submit_stac_transactions.py
+++ b/dags/veda_data_pipeline/utils/submit_stac_transactions.py
@@ -1,0 +1,121 @@
+import json
+import logging
+import requests
+from typing import List, TypedDict
+
+import boto3
+
+logging.basicConfig(level=logging.INFO)
+
+class Creds(TypedDict):
+    access_token: str
+    expires_in: int
+    token_type: str
+
+class AppConfig(TypedDict):
+    cognito_domain: str
+    client_id: str
+    client_secret: str
+    scope: str
+
+class TransactionsApi:
+
+    @classmethod
+    def from_veda_auth_secret(cls, *, secret_id: str, base_url: str) -> "IngestionApi":
+        cognito_details = cls._get_cognito_service_details(secret_id)
+        credentials = cls._get_app_credentials(**cognito_details)
+        return cls(token=credentials["access_token"], base_url=base_url)
+
+    @staticmethod
+    def _get_cognito_service_details(secret_id: str) -> AppConfig:
+        client = boto3.client("secretsmanager")
+        response = client.get_secret_value(SecretId=secret_id)
+        return json.loads(response["SecretString"])
+
+    @staticmethod
+    def _get_app_credentials(
+        cognito_domain: str, client_id: str, client_secret: str, scope: str, **kwargs
+    ) -> Creds:
+        response = requests.post(
+            f"{cognito_domain}/oauth2/token",
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            auth=(client_id, client_secret),
+            data={
+                "grant_type": "client_credentials",
+                # A space-separated list of scopes to request for the generated access token.
+                "scope": scope,
+            },
+        )
+        try:
+            response.raise_for_status()
+        except Exception as ex:
+            print(response.text)
+            raise f"Error, {ex}"
+        return response.json()
+
+    def __init__(self, stac_ingestor_api_url: str, cognito_app_secret: str = None):
+        """
+        :param stac_endpoint: Base URL of the STAC API (e.g., 'https://example.com/stac').
+        :param token: Optional Bearer token for authenticated STAC APIs.
+        """
+        self.stac_ingestor_api_url = stac_ingestor_api_url.rstrip('/')
+        self.cognito_app_secret = cognito_app_secret
+
+    def post_items(self, collection_id: str, items: List[dict]) -> dict:
+        """
+        Perform a PUT request to update or create a STAC Item in the given collection.
+
+        :param collection_id: The target collection ID.
+        :param item_id: The target item ID.
+        :param item_body: The full STAC Item JSON body.
+        :return: The JSON response (as a dict) from the STAC API.
+        :raises RuntimeError: If the response is not 200/201.
+        """
+        url = f"{self.base_url.rstrip('/')}{self.stac_ingestor_api_url}/collections/{collection_id}/bulk_items"
+        headers = {"Content-Type": "application/json"}
+
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        logging.info(f"PUT {url}")
+        response = requests.post(url, headers=headers, json=items)
+
+        if response.status_code not in (200, 201):
+            logging.error("Failed PUT request: %s %s", response.status_code, response.text)
+            raise RuntimeError(f"PUT request failed: {response.text}")
+
+        return response.json()
+
+
+def submit_transactions_handler(
+        event, 
+        cognito_app_secret=None,
+        stac_ingestor_api_url=None,
+    ):
+    """
+    Handler function that can be integrated in the same way as the existing `submission_handler`,
+    but uses the TransactionsApi to perform a PUT request to STAC's Transactions endpoint.
+
+    :param event: A dict containing the data needed for STAC item submission,
+                  including collection_id, item_id, and the STAC item body itself.
+    :param context: (Optional) context object, for AWS Lambda or similar environments.
+    :return: A dict representing the API response.
+    """
+
+    collection_id = event[0].get("collection")
+    api = TransactionsApi(stac_ingestor_api_url, cognito_app_secret)
+    try:
+        response = api.post_items(collection_id, event)
+        logging.info("STAC Item POST completed successfully.")
+    except RuntimeError as err:
+        logging.error("Error while performing POST: %s", str(err))
+        raise
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "message": "POST request completed successfully",
+            "response": response
+        })
+    }

--- a/dags/veda_data_pipeline/utils/submit_stac_transactions.py
+++ b/dags/veda_data_pipeline/utils/submit_stac_transactions.py
@@ -52,7 +52,7 @@ class TransactionsApi:
                 "client_id": id,
                 "client_secret": secret,
                 "grant_type": "client_credentials",
-                "scope": "stac:item:create stac:collection:create stac:collection:update stac:item:update"
+                "scope": "stac:item:create stac:item:update"
             },
         )
         try:
@@ -63,7 +63,7 @@ class TransactionsApi:
         return response.json()
 
 
-    def post_items(self, collection_id: str, items: List[dict]) -> dict:
+    def post_items(self, item: dict) -> dict:
         """
         Perform a PUT request to update or create a STAC Item in the given collection.
 
@@ -76,11 +76,13 @@ class TransactionsApi:
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
         }
-        bulk_items = {"items": {item['id']: item for item in items}, "method": "upsert"}
-        response = requests.post(
-            f"{self.base_url.rstrip('/')}/collections/{collection_id}/bulk_items", 
+        collection_id = item.get("collection")
+        item_id = item.get("id")
+        
+        response = requests.put(
+            f"{self.base_url.rstrip('/')}/collections/{collection_id}/items/{item_id}", 
             headers=headers, 
-            json=bulk_items
+            json=item
         )
 
         if response.status_code not in (200, 201):
@@ -105,24 +107,23 @@ def submit_transactions_handler(
     :return: A dict representing the API response.
     """
 
-    collection_id = event[0].get("collection")
+    
     api = TransactionsApi.from_veda_auth_secret(
         secret_id=cognito_app_secret,
         base_url=ingest_url,
     )
     try:
         response = api.post_items(
-            collection_id=collection_id, 
-            items=event,
+            item=event,
         )
-        logging.info("STAC Bulk Item POST completed successfully.")
+        logging.info("STAC Item PUT completed successfully.")
     except RuntimeError as err:
-        logging.error("Error while performing POST: %s", str(err))
+        logging.error("Error while performing {PUT}: %s", str(err))
         raise
     return {
         "statusCode": 200,
         "body": json.dumps({
-            "message": "POST request completed successfully",
+            "message": "PUT request completed successfully",
             "response": response
         })
     }

--- a/dags/veda_data_pipeline/utils/submit_stac_transactions.py
+++ b/dags/veda_data_pipeline/utils/submit_stac_transactions.py
@@ -2,6 +2,7 @@ import json
 import logging
 import requests
 from typing import List, TypedDict
+from dataclasses import dataclass
 
 import boto3
 
@@ -20,6 +21,7 @@ class Secret(TypedDict):
     auth_url: str
     token_url: str
 
+@dataclass
 class TransactionsApi:
     base_url: str
     token: str
@@ -50,7 +52,7 @@ class TransactionsApi:
                 "client_id": id,
                 "client_secret": secret,
                 "grant_type": "client_credentials",
-                "scopes": "stac:item:create stac:collection:create"
+                "scope": "stac:item:create stac:collection:create stac:collection:update stac:item:update"
             },
         )
         try:
@@ -61,13 +63,12 @@ class TransactionsApi:
         return response.json()
 
 
-    def post_items(self, collection_id: str, items: List[dict], endpoint: str) -> dict:
+    def post_items(self, collection_id: str, items: List[dict]) -> dict:
         """
         Perform a PUT request to update or create a STAC Item in the given collection.
 
         :param collection_id: The target collection ID.
-        :param item_id: The target item ID.
-        :param item_body: The full STAC Item JSON body.
+        :param items: list of STAC items to be submitted.
         :return: The JSON response (as a dict) from the STAC API.
         :raises RuntimeError: If the response is not 200/201.
         """

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -96,8 +96,6 @@ def transfer_assets_to_production_bucket(ti=None, payload={}):
         return payload
 
 with DAG("veda_promotion_pipeline", params=template_dag_run_conf, **dag_args) as dag:
-    # ECS dependency variable
-
     start = EmptyOperator(task_id="start", dag=dag)
     end = EmptyOperator(task_id="end", dag=dag)
 

--- a/sm2a/infrastructure/lambda_dag_trigger.tf
+++ b/sm2a/infrastructure/lambda_dag_trigger.tf
@@ -7,7 +7,7 @@
 
 resource "aws_iam_role" "lambda_dag_trigger_exec_role" {
   provider             = aws.aws_current
-  name                 = var.lambda_dag_trigger_function_name
+  name                 = "${var.prefix}-${var.lambda_dag_trigger_function_name}"
   permissions_boundary = var.permission_boundaries_arn
 
   assume_role_policy = <<EOF

--- a/sm2a/infrastructure/main.tf
+++ b/sm2a/infrastructure/main.tf
@@ -120,7 +120,7 @@ module "sma-base" {
     ASSUME_ROLE_READ_ARN = var.assume_role_read_arn
     ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn
     SM2A_BASE_URL = module.sma-base.airflow_url
-    TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled
+    TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled==true ? "True" : null
     STAC_API_KEYCLOAK_CLIENT_SECRET=var.stac_api_keycloak_client_secret
   }
 >>>>>>> c4a6e84 (use keycloak for transactionss POST)

--- a/sm2a/infrastructure/main.tf
+++ b/sm2a/infrastructure/main.tf
@@ -93,7 +93,6 @@ module "sma-base" {
   subdomain   = var.subdomain
   worker_cmd  = ["airflow", "celery", "worker"]
 
-<<<<<<< HEAD
   # add custom env, with conditional rds backup env vars
   airflow_custom_variables = merge({
     EVENT_BUCKET          = var.state_bucketname,
@@ -104,24 +103,10 @@ module "sma-base" {
     ASSUME_ROLE_READ_ARN  = var.assume_role_read_arn,
     ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn,
     SM2A_BASE_URL         = module.sma-base.airflow_url,
-    TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled,
-    STAC_API_KEYCLOAK_CLIENT_SECRET=var.stac_api_keycloak_client_secret,
     CLOUDFRONT_TO_INVALIDATE = var.cloudfront_to_invalidate,
-    CLOUDFRONT_PATH_TO_INVALIDATE = var.cloudfront_path_to_invalidate
+    CLOUDFRONT_PATH_TO_INVALIDATE = var.cloudfront_path_to_invalidate,
+    TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled==true ? "True" : null,
+    STAC_API_KEYCLOAK_CLIENT_SECRET=var.stac_api_keycloak_client_secret
   }, var.snapshot_bucket_name != "" ? module.rds_backups[0].rds_backup_environment : {}
   )
-=======
-  airflow_custom_variables = {
-    EVENT_BUCKET          = var.state_bucketname
-    COGNITO_APP_SECRET    = var.workflows_client_secret
-    STAC_INGESTOR_API_URL = var.stac_ingestor_api_url
-    STAC_URL              = var.stac_url
-    VECTOR_SECRET_NAME    = var.vector_secret_name
-    ASSUME_ROLE_READ_ARN = var.assume_role_read_arn
-    ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn
-    SM2A_BASE_URL = module.sma-base.airflow_url
-    TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled==true ? "True" : null
-    STAC_API_KEYCLOAK_CLIENT_SECRET=var.stac_api_keycloak_client_secret
-  }
->>>>>>> c4a6e84 (use keycloak for transactionss POST)
 }

--- a/sm2a/infrastructure/main.tf
+++ b/sm2a/infrastructure/main.tf
@@ -93,6 +93,7 @@ module "sma-base" {
   subdomain   = var.subdomain
   worker_cmd  = ["airflow", "celery", "worker"]
 
+<<<<<<< HEAD
   # add custom env, with conditional rds backup env vars
   airflow_custom_variables = merge({
     EVENT_BUCKET          = var.state_bucketname,
@@ -104,8 +105,23 @@ module "sma-base" {
     ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn,
     SM2A_BASE_URL         = module.sma-base.airflow_url,
     TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled,
+    STAC_API_KEYCLOAK_CLIENT_SECRET=var.stac_api_keycloak_client_secret,
     CLOUDFRONT_TO_INVALIDATE = var.cloudfront_to_invalidate,
     CLOUDFRONT_PATH_TO_INVALIDATE = var.cloudfront_path_to_invalidate
   }, var.snapshot_bucket_name != "" ? module.rds_backups[0].rds_backup_environment : {}
   )
+=======
+  airflow_custom_variables = {
+    EVENT_BUCKET          = var.state_bucketname
+    COGNITO_APP_SECRET    = var.workflows_client_secret
+    STAC_INGESTOR_API_URL = var.stac_ingestor_api_url
+    STAC_URL              = var.stac_url
+    VECTOR_SECRET_NAME    = var.vector_secret_name
+    ASSUME_ROLE_READ_ARN = var.assume_role_read_arn
+    ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn
+    SM2A_BASE_URL = module.sma-base.airflow_url
+    TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled
+    STAC_API_KEYCLOAK_CLIENT_SECRET=var.stac_api_keycloak_client_secret
+  }
+>>>>>>> c4a6e84 (use keycloak for transactionss POST)
 }

--- a/sm2a/infrastructure/main.tf
+++ b/sm2a/infrastructure/main.tf
@@ -103,7 +103,8 @@ module "sma-base" {
     ASSUME_ROLE_READ_ARN  = var.assume_role_read_arn,
     ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn,
     SM2A_BASE_URL         = module.sma-base.airflow_url,
-    CLOUDFRONT_TO_INVALIDATE = var.cloudfront_to_invalidate
+    TRANSACTIONS_ENDPOINT_ENABLED = var.transactions_endpoint_enabled,
+    CLOUDFRONT_TO_INVALIDATE = var.cloudfront_to_invalidate,
     CLOUDFRONT_PATH_TO_INVALIDATE = var.cloudfront_path_to_invalidate
   }, var.snapshot_bucket_name != "" ? module.rds_backups[0].rds_backup_environment : {}
   )

--- a/sm2a/infrastructure/variables.tf
+++ b/sm2a/infrastructure/variables.tf
@@ -243,3 +243,7 @@ variable "cloudfront_path_to_invalidate" {
 variable "lambda_dag_trigger_function_name" {
   default = "trigger-sm2a-dag"
 }
+variable "transactions_endpoint_enabled" {
+  type = bool
+  default = false
+}

--- a/sm2a/infrastructure/variables.tf
+++ b/sm2a/infrastructure/variables.tf
@@ -148,6 +148,7 @@ variable "gh_user_team_id" {
 
 variable "workflows_client_secret" {
 }
+
 variable "stac_ingestor_api_url" {
 }
 
@@ -246,4 +247,8 @@ variable "lambda_dag_trigger_function_name" {
 variable "transactions_endpoint_enabled" {
   type = bool
   default = false
+}
+
+variable stac_api_keycloak_client_secret {
+ type = string
 }


### PR DESCRIPTION
Proposed implementation for #288 

Original ingest API support is maintained through an Airflow variable. I learned while setting this up that this is [not a recommended approach](https://airflow.apache.org/docs/apache-airflow/stable/howto/dynamic-dag-generation.html#dynamic-dags-with-environment-variables), but it is consistent with what we do elsewhere.