### PR TITLE
fix: use configuration dict passed into dag run for transfer_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make sm2a-local-build
 ```shell
 make sm2a-local-init
 ```
-🚨 NOTE: This command is typically required only once at the beginning. 
+🚨 NOTE: This command is typically required only once at the beginning.
 After running it, you generally do not need to run it again unless you run `make clean`,
 which will require you to reinitialize SM2A with `make sm2a-local-init`
 
@@ -98,13 +98,13 @@ $bash ./scripts/deploy.sh .env <<< deploy
 
 ### Fetch environment variables using AWS CLI
 
-To retrieve the variables for a stage that has been previously deployed, the secrets manager can be used to quickly populate an .env file with [`scripts/sync-env-local.sh`](scripts/sync-env-local.sh). 
+To retrieve the variables for a stage that has been previously deployed, the secrets manager can be used to quickly populate an .env file with [`scripts/sync-env-local.sh`](scripts/sync-env-local.sh).
 
 ```
 ./scripts/sync-env-local.sh <app-secret-name>
 ```
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > Be careful not to check in `.env` (or whatever you called your env file) when committing work.
 
 Currently, the client id and domain of an existing Cognito user pool programmatic client must be supplied in [configuration](ingest_api/infrastructure/config.py) as `VEDA_CLIENT_ID` and `VEDA_COGNITO_DOMAIN` (the [veda-auth project](https://github.com/NASA-IMPACT/veda-auth) can be used to deploy a Cognito user pool and client). To dispense auth tokens via the workflows API swagger docs, an administrator must add the ingest API lambda URL to the allowed callbacks of the Cognito client.
@@ -136,7 +136,7 @@ This pipeline is designed to handle the ingestion of both vector and raster data
 }
 ```
 
-### Raster Data Ingestion 
+### Raster Data Ingestion
 ```json
 {
     "collection": "",

--- a/dags/veda_data_pipeline/groups/transfer_group.py
+++ b/dags/veda_data_pipeline/groups/transfer_group.py
@@ -9,10 +9,10 @@ group_kwgs = {"group_id": "Transfer", "tooltip": "Transfer"}
 
 
 def cogify_choice(ti):
-    """Choos whether to cogify or not; if yes, use a docker container"""
+    """Choose whether to cogify or not; if yes, use a docker container"""
     payload = ti.dag_run.conf
 
-    if payload.get("cogify"):
+    if payload.get("cogify") == "true" or payload.get("cogify") == True:
         return f"{group_kwgs['group_id']}.cogify_and_copy_data"
     else:
         return f"{group_kwgs['group_id']}.copy_data"
@@ -42,7 +42,7 @@ def transfer_data_task(ti=None, payload={}):
     transfer_data(config)
 
 # non-decorated function for use in other tasks
-def transfer_data(payload={}):
+def transfer_data(ti=None, payload={}):
     """Transfer data from one S3 bucket to another; s3 copy, no need for docker"""
     from veda_data_pipeline.utils.transfer import (
         data_transfer_handler,
@@ -51,6 +51,8 @@ def transfer_data(payload={}):
     airflow_vars_json = json.loads(airflow_vars)
     external_role_arn = airflow_vars_json.get("ASSUME_ROLE_WRITE_ARN")
     # (event, chunk_size=2800, role_arn=None, bucket_output=None):
+    if payload == {}:
+        payload = ti.dag_run.conf
     return data_transfer_handler(event=payload, role_arn=external_role_arn)
 
 # TODO: cogify_transfer handler is missing arg parser so this subdag will not work

--- a/dags/veda_data_pipeline/veda_transfer_pipeline.py
+++ b/dags/veda_data_pipeline/veda_transfer_pipeline.py
@@ -38,8 +38,8 @@ templat_dag_run_conf = {
     "filename_regex": "<file_regex>",
     "target_bucket": "<target_bucket>",
     "collection": "<collection-id>",
-    "cogify": Param(type="boolean"),
-    "dry_run": "true|false",
+    "cogify": Param(default=False, type="boolean"),
+    "dry_run": Param(type="boolean"),
 }
 
 with DAG("veda_transfer", params=templat_dag_run_conf, **dag_args) as dag:

--- a/dags/veda_data_pipeline/veda_transfer_pipeline.py
+++ b/dags/veda_data_pipeline/veda_transfer_pipeline.py
@@ -39,7 +39,7 @@ templat_dag_run_conf = {
     "target_bucket": "<target_bucket>",
     "collection": "<collection-id>",
     "cogify": Param(default=False, type="boolean"),
-    "dry_run": Param(type="boolean"),
+    "dry_run": Param(default=False, type="boolean"),
 }
 
 with DAG("veda_transfer", params=templat_dag_run_conf, **dag_args) as dag:

--- a/dags/veda_data_pipeline/veda_transfer_pipeline.py
+++ b/dags/veda_data_pipeline/veda_transfer_pipeline.py
@@ -1,6 +1,7 @@
 import pendulum
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.models.param import Param
 from airflow.utils.trigger_rule import TriggerRule
 from veda_data_pipeline.groups.transfer_group import subdag_transfer
 
@@ -19,7 +20,7 @@ This DAG is used to transfer files that are to permanent locations for indexing 
     "collection": "collection-id",
     "cogify": false,
     "dry_run": true
-}	
+}
 ```
 - [Supports linking to external content](https://github.com/NASA-IMPACT/veda-data-pipelines)
 """
@@ -37,7 +38,7 @@ templat_dag_run_conf = {
     "filename_regex": "<file_regex>",
     "target_bucket": "<target_bucket>",
     "collection": "<collection-id>",
-    "cogify": "true|false",
+    "cogify": Param(type="boolean"),
     "dry_run": "true|false",
 }
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [VEDA-295: Develop amazing new feature](https://github.com/NASA-IMPACT/veda-data-airflow/issues/295)

## Changes

* Updates `cogify_branching` to explicitly check for `true` or `True` because, when testing with `cogify: 'false'`, it would cofigy and copy data.
* Updates `transfer_data` to rely on `ti.dag_run.conf` if payload is {}. 

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests