### PR TITLE
Add invalidation to vector ingest DAG

### DIFF
--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -1,11 +1,12 @@
+import logging
 import pendulum
+from airflow.models.param import Param
 from airflow.decorators import task
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.models.variable import Variable
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_to_process
-import json
 
 dag_doc_md = """
 ### Build and submit stac
@@ -31,25 +32,28 @@ This DAG is supposed to be triggered by `veda_discover`. But you still can trigg
     "extra_flags": ["-overwrite", "-lco", "OVERWRITE=YES", "-oo", "X_POSSIBLE_NAMES=latitude", "-oo", "Y_POSSIBLE_NAMES=lomgitude"]
     "discovered": 33,
     "payload": "s3://data-pipeline-ghgc-dev-mwaa-597746869805/events/test_layer_name2/s3_discover_output_f88257e8-ee50-4a14-ace4-5612ae6ebf38.jsonn"
+    "invalidate_cloudfront": true
+
 }	
 ```
 - [Supports linking to external content](https://github.com/NASA-IMPACT/veda-data-pipelines)
 """
 
 template_dag_run_conf = {
-    "collection": "<collection_name>",
-    "prefix": "<prefix>/",
+    "collection":  Param("collection_name", type="string"),
+    "prefix": Param("<prefix>/", type="string", help="Must have a trailing slash"),
     "bucket": "<bucket>",
     "filename_regex": "<filename_regex>",
     "id_template": "<id_template_prefix>-{}",
     "datetime_range": "<month>|<day>",
-    "vector": "false | true",
+    "vector": Param(True, type="boolean"),
     "x_possible": "<x_column_name>",
     "y_possible": "<y_column_name>",
     "source_projection": "<crs>",
     "target_projection": "<crs>",
     "extra_flags": "<args>",
     "payload": "<s3_uri_event_payload>",
+    "invalidate_cloudfront": Param(True, type="boolean")
 }
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
@@ -63,19 +67,50 @@ dag_args = {
 def ingest_vector_task(payload):
     from veda_data_pipeline.utils.vector_ingest.handler import handler
 
-    airflow_vars = Variable.get("aws_dags_variables")
-    airflow_vars_json = json.loads(airflow_vars)
+    airflow_vars_json = Variable.get("aws_dags_variables", deserialize_json=True)
     read_role_arn = airflow_vars_json.get("ASSUME_ROLE_READ_ARN")
     vector_secret_name = airflow_vars_json.get("VECTOR_SECRET_NAME")
     return handler(payload_src=payload, vector_secret_name=vector_secret_name,
                    assume_role_arn=read_role_arn)
 
 
+@task
+def invalidate_cloudfront(ti):
+    import boto3
+    if not ti.dag_run.conf['invalidate_cloudfront']:
+        logging.info("Skipping cloudfront invalidation")
+        return
+
+
+    try:
+        airflow_vars_json = Variable.get("aws_dags_variables", deserialize_json=True)
+        cloudfront_to_invalidate_id = airflow_vars_json.get("CLOUDFRONT_TO_INVALIDATE")
+        cloudfront_path_to_invalidate = airflow_vars_json.get("CLOUDFRONT_PATH_TO_INVALIDATE")
+
+        if cloudfront_to_invalidate_id and cloudfront_path_to_invalidate:
+            client = boto3.client('cloudfront')
+            response = client.create_invalidation(
+                DistributionId=cloudfront_to_invalidate_id,
+                InvalidationBatch={
+                    'Paths': {
+                        'Quantity': 1,
+                        'Items': [cloudfront_path_to_invalidate]
+                    },
+                    'CallerReference': str(hash(cloudfront_path_to_invalidate))
+                }
+            )
+
+            print(f"Invalidation created: {response['Invalidation']['Id']}")
+            return response
+
+        logging.error("Missing CloudFront distribution ID or path to invalidate.")
+    except Exception as e:
+        logging.error(f"Error invalidating CloudFront: {e}")
+
+
 with DAG(dag_id="veda_ingest_vector", params=template_dag_run_conf, **dag_args) as dag:
     start = DummyOperator(task_id="Start", dag=dag)
     end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
-    discover = discover_from_s3_task()
+    discover = start >> discover_from_s3_task()
     get_files = get_files_to_process(payload=discover)
-    vector_ingest = ingest_vector_task.expand(payload=get_files)
-    discover.set_upstream(start)
-    vector_ingest.set_downstream(end)
+    vector_ingest = ingest_vector_task.expand(payload=get_files) >> invalidate_cloudfront() >> end

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -110,4 +110,6 @@ def invalidate_cloudfront(ti):
 with DAG(dag_id="veda_ingest_vector", params=template_dag_run_conf, **dag_args) as dag:
     start = DummyOperator(task_id="Start", dag=dag)
     end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
-    discover = start >> invalidate_cloudfront() >> end
+    discover = start >> discover_from_s3_task()
+    get_files = get_files_to_process(payload=discover)
+    vector_ingest = ingest_vector_task.expand(payload=get_files) >> invalidate_cloudfront() >> end

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -40,7 +40,7 @@ This DAG is supposed to be triggered by `veda_discover`. But you still can trigg
 """
 
 template_dag_run_conf = {
-    "collection":  Param("collection_name", type="string"),
+    "collection": Param("collection_name", type="string"),
     "prefix": Param("<prefix>/", type="string", help="Must have a trailing slash"),
     "bucket": "<bucket>",
     "filename_regex": "<filename_regex>",
@@ -81,7 +81,6 @@ def invalidate_cloudfront(ti):
         logging.info("Skipping cloudfront invalidation")
         return
 
-
     try:
         airflow_vars_json = Variable.get("aws_dags_variables", deserialize_json=True)
         cloudfront_to_invalidate_id = airflow_vars_json.get("CLOUDFRONT_TO_INVALIDATE")
@@ -111,6 +110,4 @@ def invalidate_cloudfront(ti):
 with DAG(dag_id="veda_ingest_vector", params=template_dag_run_conf, **dag_args) as dag:
     start = DummyOperator(task_id="Start", dag=dag)
     end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
-    discover = start >> discover_from_s3_task()
-    get_files = get_files_to_process(payload=discover)
-    vector_ingest = ingest_vector_task.expand(payload=get_files) >> invalidate_cloudfront() >> end
+    discover = start >> invalidate_cloudfront() >> end

--- a/sm2a/infrastructure/main.tf
+++ b/sm2a/infrastructure/main.tf
@@ -17,6 +17,7 @@ resource "random_password" "password" {
 }
 
 
+
 module "sma-base" {
   source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.5/self-managed-apache-airflow.zip"
   project                        = var.project_name
@@ -90,6 +91,8 @@ module "sma-base" {
     ASSUME_ROLE_READ_ARN  = var.assume_role_read_arn
     ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn
     SM2A_BASE_URL         = module.sma-base.airflow_url
+    CLOUDFRONT_TO_INVALIDATE = var.cloudfront_to_invalidate
+    CLOUDFRONT_PATH_TO_INVALIDATE = var.cloudfront_path_to_invalidate
   }
 }
 

--- a/sm2a/infrastructure/variables.tf
+++ b/sm2a/infrastructure/variables.tf
@@ -100,7 +100,7 @@ variable "custom_worker_policy_statement" {
     },
     {
             "Effect": "Allow",
-            "Action": "cloudfront:CreateInvalidation",
+            "Action": ["cloudfront:CreateInvalidation"],
             "Resource": "arn:aws:cloudfront::*:distribution/*"
     }
 

--- a/sm2a/infrastructure/variables.tf
+++ b/sm2a/infrastructure/variables.tf
@@ -97,6 +97,11 @@ variable "custom_worker_policy_statement" {
         "*"
       ]
 
+    },
+    {
+            "Effect": "Allow",
+            "Action": "cloudfront:CreateInvalidation",
+            "Resource": "arn:aws:cloudfront::*:distribution/*"
     }
 
   ]
@@ -181,4 +186,11 @@ variable "assume_role_read_arn" {
 variable "assume_role_write_arn" {
   type = string
   default = ""
+}
+
+variable "cloudfront_to_invalidate" {
+  default = null
+}
+variable "cloudfront_path_to_invalidate" {
+  default = null
 }

--- a/sm2a/infrastructure/variables.tf
+++ b/sm2a/infrastructure/variables.tf
@@ -101,7 +101,7 @@ variable "custom_worker_policy_statement" {
     {
             "Effect": "Allow",
             "Action": ["cloudfront:CreateInvalidation"],
-            "Resource": "arn:aws:cloudfront::*:distribution/*"
+            "Resource": ["arn:aws:cloudfront::*:distribution/*"]
     }
 
   ]


### PR DESCRIPTION
**Summary:** Summary of changes

Adding a cloudfront invalidation after vector ingest step
## Changes

* We need to invalidate the cache of feature API to be able to read new data
