### PR TITLE
feat: schedule multitple dag types

### DIFF
--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -7,7 +7,7 @@ from airflow.models.variable import Variable
 from typing import Dict, List, Optional
 
 from veda_data_pipeline.veda_discover_pipeline import get_discover_dag
-from veda_data_pipeline.veda_vector_pipeline import get_vector_ingest_dag
+from veda_data_pipeline.veda_vector_pipeline import get_ingest_vector_dag
 
 def filter_configs_by_dag(
         collection_configs: List[Dict[str, int]], 
@@ -79,13 +79,13 @@ def generate_dags():
             )
 
         # veda_vector_ingest
-        scheduled_vector_configs = filter_configs_by_dag(collection_configs, "veda_vector_ingest")
+        scheduled_vector_configs = filter_configs_by_dag(collection_configs, "veda_ingest_vector")
 
         for idx, vector_config in enumerate(scheduled_vector_configs):
             id = f"vector-{file_name}"
             if idx > 0:
                 id = f"{id}-{idx}"
-            get_vector_ingest_dag(
+            get_ingest_vector_dag(
                 id=id, event=vector_config
             )
 

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -4,9 +4,29 @@ These DAGs are used to discover and ingest items for each collection.
 """
 
 from airflow.models.variable import Variable
+from typing import Dict, List, Optional
 
 from veda_data_pipeline.veda_discover_pipeline import get_discover_dag
+from veda_data_pipeline.veda_vector_pipeline import get_vector_ingest_dag
 
+def filter_configs_by_dag(
+        collection_configs: List[Dict[str, int]], 
+        dag: Optional[str] = "veda_discover"
+    ) -> List[Dict[str, int]]:
+    """
+    Args:
+        collection_configs: The list of configs to filter
+        dag: The DAG name to filter for (default is veda_discover).
+
+    Returns:
+        A new list containing only the collection configs that match the filter criteria.
+    """
+    
+    filtered_configs = []
+    for c in collection_configs:
+        if c.get("schedule", None) and c.get("dag", "veda_discover") == dag:
+            filtered_configs.append(c)
+    return filtered_configs
 
 def generate_dags():
     import boto3
@@ -39,23 +59,45 @@ def generate_dags():
             continue
         file_name = Path(key).stem
         result = client.get_object(Bucket=bucket, Key=key)
-        discovery_configs = result["Body"].read().decode()
-        discovery_configs = json.loads(discovery_configs)
+        collection_configs = result["Body"].read().decode()
+        collection_configs = json.loads(collection_configs)
 
         # Allow the file content to be either one config or a list of configs
-        if type(discovery_configs) is dict:
-            discovery_configs = [discovery_configs]
-        scheduled_discovery_configs = [
-            discovery_config
-                for discovery_config in discovery_configs
-                    if discovery_config.get("schedule")
-            ]
+        if type(collection_configs) is dict:
+            collection_configs = [collection_configs]
+
+        # Filter and handle collection configs by DAG
+
+        # veda_discover
+        scheduled_discovery_configs = filter_configs_by_dag(collection_configs, "veda_discover")
         for idx, discovery_config in enumerate(scheduled_discovery_configs):
             id = f"discover-{file_name}"
             if idx > 0:
                 id = f"{id}-{idx}"
             get_discover_dag(
                 id=id, event=discovery_config
+            )
+
+        # veda_vector_ingest
+        scheduled_vector_configs = filter_configs_by_dag(collection_configs, "veda_vector_ingest")
+
+        for idx, vector_config in enumerate(scheduled_vector_configs):
+            id = f"vector-{file_name}"
+            if idx > 0:
+                id = f"{id}-{idx}"
+            get_vector_ingest_dag(
+                id=id, event=vector_config
+            )
+
+        # veda_transfer
+        scheduled_transfer_configs = filter_configs_by_dag(collection_configs, "veda_transfer")
+
+        for idx, transfer_config in enumerate(scheduled_transfer_configs):
+            id = f"transfer-{file_name}"
+            if idx > 0:
+                id = f"{id}-{idx}"
+            get_transfer_dag(
+                id=id, event=transfer_config
             )
 
 

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -89,16 +89,4 @@ def generate_dags():
                 id=id, event=vector_config
             )
 
-        # veda_transfer TODO
-        # scheduled_transfer_configs = filter_configs_by_dag(collection_configs, "veda_transfer")
-
-        # for idx, transfer_config in enumerate(scheduled_transfer_configs):
-        #     id = f"transfer-{file_name}"
-        #     if idx > 0:
-        #         id = f"{id}-{idx}"
-        #     get_transfer_dag(
-        #         id=id, event=transfer_config
-        #     )
-
-
 generate_dags()

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -89,16 +89,16 @@ def generate_dags():
                 id=id, event=vector_config
             )
 
-        # veda_transfer
-        scheduled_transfer_configs = filter_configs_by_dag(collection_configs, "veda_transfer")
+        # veda_transfer TODO
+        # scheduled_transfer_configs = filter_configs_by_dag(collection_configs, "veda_transfer")
 
-        for idx, transfer_config in enumerate(scheduled_transfer_configs):
-            id = f"transfer-{file_name}"
-            if idx > 0:
-                id = f"{id}-{idx}"
-            get_transfer_dag(
-                id=id, event=transfer_config
-            )
+        # for idx, transfer_config in enumerate(scheduled_transfer_configs):
+        #     id = f"transfer-{file_name}"
+        #     if idx > 0:
+        #         id = f"{id}-{idx}"
+        #     get_transfer_dag(
+        #         id=id, event=transfer_config
+        #     )
 
 
 generate_dags()

--- a/dags/veda_data_pipeline/utils/vector_ingest/handler.py
+++ b/dags/veda_data_pipeline/utils/vector_ingest/handler.py
@@ -364,12 +364,15 @@ def handler(payload_src: dict, vector_secret_name: str, assume_role_arn: [str, N
         print(f"[ DOWNLOAD FILEPATH ]: {downloaded_filepath}")
         print(f"[ COLLECTION ]: {collection}")
 
+        # Note that the boto3 ListObjectsV2 response is transformed to use new keys in veda_data_pipelline/utils/s3_discovery.py discover_from_s3
         s3_object_prefix = event_received["prefix"]
         if s3_object_prefix.startswith("EIS/"):
             s3_event_key = s3_object["s3"]["object"]["key"]
+            last_modified = s3_object["s3"]["object"]["last_modified"]
             s3_filename_target = os.path.split(s3_event_key)[-1]
             s3_filename_no_ext = os.path.splitext(s3_filename_target)[0]
             collection = s3_filename_no_ext
+            print(f"Load new features for eis_fire_{collection} from {s3_event_key=} {last_modified=}")
             coll_status = load_to_featuresdb_eis(downloaded_filepath, collection, vector_secret_name)
         else:
             # Get the filename

--- a/dags/veda_data_pipeline/utils/vector_ingest/handler.py
+++ b/dags/veda_data_pipeline/utils/vector_ingest/handler.py
@@ -366,6 +366,10 @@ def handler(payload_src: dict, vector_secret_name: str, assume_role_arn: [str, N
 
         s3_object_prefix = event_received["prefix"]
         if s3_object_prefix.startswith("EIS/"):
+            s3_event_key = s3_object["s3"]["object"]["key"]
+            s3_filename_target = os.path.split(s3_event_key)[-1]
+            s3_filename_no_ext = os.path.splitext(s3_filename_target)[0]
+            collection = s3_filename_no_ext
             coll_status = load_to_featuresdb_eis(downloaded_filepath, collection, vector_secret_name)
         else:
             # Get the filename

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -80,7 +80,7 @@ def ingest_vector_task(payload):
 #     discover.set_upstream(start)
 #     vector_ingest.set_downstream(end)
 
-def get_vector_ingest_dag(id, event={}):
+def get_ingest_vector_dag(id, event={}):
     
     params_dag_run_conf = event or template_dag_run_conf
 
@@ -99,5 +99,5 @@ def get_vector_ingest_dag(id, event={}):
 
         return dag
     
-get_vector_ingest_dag("veda_ingest_vector")
+get_ingest_vector_dag("veda_ingest_vector")
 

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -71,11 +71,33 @@ def ingest_vector_task(payload):
                    assume_role_arn=read_role_arn)
 
 
-with DAG(dag_id="veda_ingest_vector", params=template_dag_run_conf, **dag_args) as dag:
-    start = DummyOperator(task_id="Start", dag=dag)
-    end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
-    discover = discover_from_s3_task()
-    get_files = get_files_to_process(payload=discover)
-    vector_ingest = ingest_vector_task.expand(payload=get_files)
-    discover.set_upstream(start)
-    vector_ingest.set_downstream(end)
+# with DAG(dag_id="veda_ingest_vector", params=template_dag_run_conf, **dag_args) as dag:
+#     start = DummyOperator(task_id="Start", dag=dag)
+#     end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
+#     discover = discover_from_s3_task()
+#     get_files = get_files_to_process(payload=discover)
+#     vector_ingest = ingest_vector_task.expand(payload=get_files)
+#     discover.set_upstream(start)
+#     vector_ingest.set_downstream(end)
+
+def get_vector_ingest_dag(id, event={}):
+    
+    params_dag_run_conf = event or template_dag_run_conf
+
+    with DAG(
+            id, 
+            params=params_dag_run_conf, 
+            **dag_args
+        ) as dag:
+        start = DummyOperator(task_id="Start", dag=dag)
+        end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
+        discover = discover_from_s3_task()
+        get_files = get_files_to_process(payload=discover)
+        vector_ingest = ingest_vector_task.expand(payload=get_files)
+        discover.set_upstream(start)
+        vector_ingest.set_downstream(end)
+
+        return dag
+    
+get_vector_ingest_dag("veda_ingest_vector")
+

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -70,16 +70,6 @@ def ingest_vector_task(payload):
     return handler(payload_src=payload, vector_secret_name=vector_secret_name,
                    assume_role_arn=read_role_arn)
 
-
-# with DAG(dag_id="veda_ingest_vector", params=template_dag_run_conf, **dag_args) as dag:
-#     start = DummyOperator(task_id="Start", dag=dag)
-#     end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
-#     discover = discover_from_s3_task()
-#     get_files = get_files_to_process(payload=discover)
-#     vector_ingest = ingest_vector_task.expand(payload=get_files)
-#     discover.set_upstream(start)
-#     vector_ingest.set_downstream(end)
-
 def get_ingest_vector_dag(id, event={}):
     
     params_dag_run_conf = event or template_dag_run_conf


### PR DESCRIPTION
## What
This change generalizes the generate dags method to allow us to configure additional custom scheduled versions of existing DAGs.

- default generate dag type will continue to be veda_discover for backwards compatibility
- additional support added for veda_ingest_vector (after testing we can also add a scheduled transfer for ongoing collections with item assets are first added to veda-data-store-staging before promotion to prod

#284

## Testing
We cannot deploy these changes to SIT for testing because of an airflow UI login that requires administrator configuration. I have confirmed that the terraform plan (after init) appears correct. Further testing will need to happen in dev once deployed.