### PR TITLE
fix: explicitly add schedule interval instead of trusting template

### DIFF
--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -75,7 +75,8 @@ def get_ingest_vector_dag(id, event={}):
     params_dag_run_conf = event or template_dag_run_conf
 
     with DAG(
-            id, 
+            id,
+            schedule_interval=event.get("schedule"),
             params=params_dag_run_conf, 
             **dag_args
         ) as dag:


### PR DESCRIPTION
# What
Generate vector dag method needs to explicitly load schedule.