### PR TITLE
Fix/dynamic dag args

### DIFF
--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -14,19 +14,19 @@ group_kwgs = {"group_id": "Discover", "tooltip": "Discover"}
 
 
 @task(retries=1, retry_delay=timedelta(minutes=1))
-def discover_from_s3_task(ti=None, event={}, **kwargs):
+def discover_from_s3_task(*, event: dict = {}, ti=None, payload: dict ={}, prev_start_date_success: str = None):
     """Discover grouped assets/files from S3 in batches of 2800. Produce a list of such files stored on S3 to process.
     This task is used as part of the discover_group subdag and outputs data to EVENT_BUCKET.
     """
-    payload = kwargs.get("payload", ti.dag_run.conf)
+
+    payload = payload or ti.dag_run.conf
     config = {
         **event,
         **payload,
     }
     # TODO test that this context var is available in taskflow
-    last_successful_execution = kwargs.get("prev_start_date_success")
-    if event.get("schedule") and last_successful_execution:
-        config["last_successful_execution"] = last_successful_execution.isoformat()
+    if event.get("schedule") and prev_start_date_success:
+        config["last_successful_execution"] = prev_start_date_success.isoformat()
     # (event, chunk_size=2800, role_arn=None, bucket_output=None):
 
     airflow_vars = Variable.get("aws_dags_variables")

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -14,7 +14,7 @@ group_kwgs = {"group_id": "Discover", "tooltip": "Discover"}
 
 
 @task(retries=1, retry_delay=timedelta(minutes=1))
-def discover_from_s3_task(*, event: dict = {}, ti=None, payload: dict ={}, prev_start_date_success: str = None):
+def discover_from_s3_task(*, event: dict={}, ti=None, payload: dict={}, prev_start_date_success: str=None):
     """Discover grouped assets/files from S3 in batches of 2800. Produce a list of such files stored on S3 to process.
     This task is used as part of the discover_group subdag and outputs data to EVENT_BUCKET.
     """

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -225,7 +225,7 @@ def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=No
     )
     # Note that the boto3 ListObjectsV2 response is transformed to use new keys in veda_data_pipelline/utils/s3_discovery.py discover_from_s3
     file_uris = [
-        f"s3://{bucket}/{obj['key']}" 
+        f"s3://{bucket}/{obj['Key']}" 
         for obj in discover_from_s3(
             s3_iterator, filename_regex, last_execution=process_from or last_execution
         )

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -190,7 +190,7 @@ def propagate_forward_datetime_args(event):
 
 
 def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=None):
-    bucket = event.get("bucket")
+    bucket = event["bucket"]
     prefix = event.get("prefix", "")
     filename_regex = event.get("filename_regex", None)
     collection = event.get("collection", prefix.rstrip("/"))
@@ -223,8 +223,9 @@ def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=No
     s3_iterator = get_s3_resp_iterator(
         bucket_name=bucket, prefix=prefix, s3_client=s3client
     )
+    # Note that the boto3 ListObjectsV2 response is transformed to use new keys in veda_data_pipelline/utils/s3_discovery.py discover_from_s3
     file_uris = [
-        f"s3://{bucket}/{obj['Key']}"
+        f"s3://{bucket}/{obj['key']}" 
         for obj in discover_from_s3(
             s3_iterator, filename_regex, last_execution=process_from or last_execution
         )

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -224,7 +224,7 @@ def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=No
         bucket_name=bucket, prefix=prefix, s3_client=s3client
     )
     file_uris = [
-        f"s3://{bucket}/{obj['Key']}" 
+        f"s3://{bucket}/{obj['Key']}"
         for obj in discover_from_s3(
             s3_iterator, filename_regex, last_execution=process_from or last_execution
         )

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -223,7 +223,6 @@ def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=No
     s3_iterator = get_s3_resp_iterator(
         bucket_name=bucket, prefix=prefix, s3_client=s3client
     )
-    # Note that the boto3 ListObjectsV2 response is transformed to use new keys in veda_data_pipelline/utils/s3_discovery.py discover_from_s3
     file_uris = [
         f"s3://{bucket}/{obj['Key']}" 
         for obj in discover_from_s3(

--- a/dags/veda_data_pipeline/utils/s3_discovery.py
+++ b/dags/veda_data_pipeline/utils/s3_discovery.py
@@ -191,7 +191,7 @@ def propagate_forward_datetime_args(event):
 
 def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=None):
     bucket = event["bucket"]
-    prefix = event.get("prefix", "")
+    prefix = event["prefix"]
     filename_regex = event.get("filename_regex", None)
     collection = event.get("collection", prefix.rstrip("/"))
     properties = event.get("properties", {})

--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -69,18 +69,12 @@ template_dag_run_conf = {
     },
 }
 
+def get_discover_dag(*, id: str, event: dict):
 
-
-
-
-def get_discover_dag(id, event=None):
-    if not event:
-        event = {}
-    params_dag_run_conf = event or template_dag_run_conf
     with DAG(
             id,
             schedule_interval=event.get("schedule"),
-            params=params_dag_run_conf,
+            params=event,
             **dag_args
     ) as dag:
         start = DummyOperator(task_id="Start", dag=dag)
@@ -101,4 +95,4 @@ def get_discover_dag(id, event=None):
         return dag
 
 
-get_discover_dag("veda_discover")
+get_discover_dag(id="veda_discover", event=template_dag_run_conf)

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -54,7 +54,7 @@ template_dag_run_conf = {
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
     "catchup": False,
-    "doc_md": dag_doc_md
+    "doc_md": dag_doc_md,
 }
 
 

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -54,7 +54,7 @@ template_dag_run_conf = {
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
     "catchup": False,
-    "doc_md": dag_doc_md,
+    "doc_md": dag_doc_md
 }
 
 
@@ -69,19 +69,17 @@ def ingest_vector_task(payload):
     return handler(payload_src=payload, vector_secret_name=vector_secret_name,
                    assume_role_arn=read_role_arn)
 
-def get_ingest_vector_dag(id, event={}):
-    
-    params_dag_run_conf = event or template_dag_run_conf
+def get_ingest_vector_dag(*, id: str, event: dict):
 
     with DAG(
             id,
-            schedule_interval=params_dag_run_conf.get("schedule", None),
-            params=params_dag_run_conf, 
+            schedule_interval=event.get("schedule", None),
+            params=event, 
             **dag_args
         ) as dag:
         start = DummyOperator(task_id="Start", dag=dag)
         end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
-        discover = discover_from_s3_task()
+        discover = discover_from_s3_task(event)
         get_files = get_files_to_process(payload=discover)
         vector_ingest = ingest_vector_task.expand(payload=get_files)
         discover.set_upstream(start)
@@ -89,5 +87,5 @@ def get_ingest_vector_dag(id, event={}):
 
         return dag
     
-get_ingest_vector_dag("veda_ingest_vector")
+get_ingest_vector_dag(id="veda_ingest_vector", event=template_dag_run_conf)
 


### PR DESCRIPTION
## What
Some code updates for clarity (not across the full codebase, just in discovery and vector DAGs)
- Don't ignore a missing bucket arg in the event config. Event.get('bucket') should fail if bucket is not provided so use event['bucket']--this will emit a useful error
- require named parameters