### PR TITLE
fix: adjust s3 discovery group signature to accept hidden airflow kwargs

### DIFF
--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -14,7 +14,7 @@ group_kwgs = {"group_id": "Discover", "tooltip": "Discover"}
 
 
 @task(retries=1, retry_delay=timedelta(minutes=1))
-def discover_from_s3_task(*, event: dict={}, ti=None, payload: dict={}, prev_start_date_success: str=None):
+def discover_from_s3_task(event: dict={}, ti=None, payload: dict={}, prev_start_date_success: str=None):
     """Discover grouped assets/files from S3 in batches of 2800. Produce a list of such files stored on S3 to process.
     This task is used as part of the discover_group subdag and outputs data to EVENT_BUCKET.
     """


### PR DESCRIPTION
# what
Remove keyword only operator from discover_from_s3_task to resolve DAG import kwargs error