### PR TITLE
Update Airflow to 2.10.5

### DIFF
--- a/airflow_services/Dockerfile
+++ b/airflow_services/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 apache/airflow:slim-2.8.4-python3.11
+FROM --platform=linux/amd64 apache/airflow:slim-2.10.5-python3.11
 
-ARG AIRFLOW_VERSION=2.8.4
+ARG AIRFLOW_VERSION=2.10.5
 
 USER root
 # `apt-get autoremove` is used to remove packages that were automatically installed to satisfy

--- a/airflow_services/Dockerfile
+++ b/airflow_services/Dockerfile
@@ -21,6 +21,8 @@ USER airflow
 RUN uv pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
   && uv pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
 
+ENV PATH=".venv/bin:$PATH"
+
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"
 COPY --chown=airflow:airflow plugins "${AIRFLOW_HOME}/plugins"
 COPY --chown=airflow:airflow infrastructure/configuration "${AIRFLOW_HOME}/configuration"

--- a/airflow_services/Dockerfile
+++ b/airflow_services/Dockerfile
@@ -18,9 +18,8 @@ COPY --chown=airflow:airflow airflow_services/requirements-in.txt "${AIRFLOW_HOM
 
 USER airflow
 
-RUN pip install --upgrade pip \
-  && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
-  && pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
+RUN uv pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
+  && uv pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
 
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"
 COPY --chown=airflow:airflow plugins "${AIRFLOW_HOME}/plugins"

--- a/airflow_worker/Dockerfile
+++ b/airflow_worker/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /opt/airflow
 RUN chown $UNAME:$GID /opt/airflow
 
 RUN apt-get -y update \
-        && apt-get install -y --no-install-recommends gcc libc6-dev libcurl4-openssl-dev libssl-dev \
+        && apt-get install -y --no-install-recommends gcc libc6-dev libcurl4-openssl-dev libssl-dev python3.11 python3.11-venv python3.11-dev \
         && apt-get autoremove -yqq --purge \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
@@ -25,9 +25,7 @@ USER airflow
 COPY --chown=airflow:airflow airflow_worker/requirements.txt "${AIRFLOW_HOME}/requirements.txt"
 COPY --chown=airflow:airflow airflow_worker/requirements-in.txt "${AIRFLOW_HOME}/requirements-in.txt"
 
-RUN uv python install 3.11
-RUN uv venv
-
+RUN uv venv --python python3.11
 RUN uv pip install "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}" -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
     && uv pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
     && uv pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}

--- a/airflow_worker/Dockerfile
+++ b/airflow_worker/Dockerfile
@@ -32,6 +32,8 @@ RUN uv pip install "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}" -c "https
     && uv pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
     && uv pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
 
+ENV PATH=".venv/bin:$PATH"
+
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"
 COPY --chown=airflow:airflow plugins "${AIRFLOW_HOME}/plugins"
 COPY --chown=airflow:airflow infrastructure/configuration "${AIRFLOW_HOME}/configuration"

--- a/airflow_worker/Dockerfile
+++ b/airflow_worker/Dockerfile
@@ -1,16 +1,13 @@
-FROM --platform=linux/amd64 osgeo/gdal:ubuntu-small-3.6.3
+FROM --platform=linux/amd64 ghcr.io/osgeo/gdal:ubuntu-small-3.6.4
+COPY --from=ghcr.io/astral-sh/uv:0.7.3 /uv /uvx /bin/
+
 ARG AIRFLOW_VERSION=2.10.5
-
 ARG UNAME=airflow
-
 ARG UID=50000
-
 ARG GID=0
-
 ARG AIRFLOW_HOME=/opt/airflow
 
 RUN groupadd -g $GID -o $UNAME
-
 RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
 
 WORKDIR /opt/airflow
@@ -25,25 +22,15 @@ RUN apt-get -y update \
 
 USER airflow
 
-
-RUN mkdir -p /home/airflow/miniconda3 \
-    && curl -o /home/airflow/miniconda3/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && bash /home/airflow/miniconda3/miniconda.sh -b -u -p /home/airflow/miniconda3 \
-    && rm /home/airflow/miniconda3/miniconda.sh
-
-# Install python 3.11
-RUN /home/airflow/miniconda3/bin/conda create -n py11 --yes python=3.11
-
-ENV PATH $PATH:/home/airflow/miniconda3/envs/py11/bin
-
-
 COPY --chown=airflow:airflow airflow_worker/requirements.txt "${AIRFLOW_HOME}/requirements.txt"
 COPY --chown=airflow:airflow airflow_worker/requirements-in.txt "${AIRFLOW_HOME}/requirements-in.txt"
 
-RUN pip install --upgrade pip \
-    && pip install "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}" -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
-    && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
-    && pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
+RUN uv python install 3.11
+RUN uv venv
+
+RUN uv pip install "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}" -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
+    && uv pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
+    && uv pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
 
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"
 COPY --chown=airflow:airflow plugins "${AIRFLOW_HOME}/plugins"

--- a/airflow_worker/Dockerfile
+++ b/airflow_worker/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=linux/amd64 osgeo/gdal:ubuntu-small-3.6.3
-ARG AIRFLOW_VERSION=2.8.4
+ARG AIRFLOW_VERSION=2.10.5
 
 ARG UNAME=airflow
 

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -4,6 +4,7 @@ import uuid
 
 from airflow.models.variable import Variable
 from airflow.decorators import task
+from airflow.models.xcom import LazyXComSelectSequence
 from veda_data_pipeline.utils.s3_discovery import (
     s3_discovery_handler, EmptyFileListError
 )
@@ -60,7 +61,7 @@ def get_files_task(payload, ti=None):
     payloads = payload if isinstance(payload, list) else [payload]
 
     for item in payloads:
-        if isinstance(item, list):  # Dynamic task mapping case
+        if isinstance(item, LazyXComSelectSequence):  # Dynamic task mapping case
             payloads_xcom = item[0].pop("payload", [])
             base_payload = item[0]
         else:
@@ -82,7 +83,7 @@ def get_files_to_process(payload, ti=None):
     """Get files from S3 produced by the discovery task.
     Used as part of both the parallel_run_process_rasters and parallel_run_process_vectors tasks.
     """
-    if isinstance(payload, list):  # if used as part of a dynamic task mapping
+    if isinstance(payload, LazyXComSelectSequence):  # if used as part of a dynamic task mapping
         payloads_xcom = payload[0].pop("payload", [])
         payload = payload[0]
     else:
@@ -105,7 +106,7 @@ def get_dataset_files_to_process(payload, ti=None):
 
     result = []
     for x in payload:
-        if isinstance(x, list):  # if used as part of a dynamic task mapping
+        if isinstance(x, LazyXComSelectSequence):  # if used as part of a dynamic task mapping
             payloads_xcom = x[0].pop("payload", [])
             payload_0 = x[0]
         else:

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -23,11 +23,6 @@ def discover_from_s3_task(event: dict={}, ti=None, payload: dict={}, prev_start_
         **event,
         **payload,
     }
-    # If the DAG is triggered by a schedule add the configuration to DAG run
-    if not ti.dag_run.conf:
-        ti.dag_run.conf = config
-
-    # TODO test that this context var is available in taskflow
     if event.get("schedule") and prev_start_date_success:
         config["last_successful_execution"] = prev_start_date_success.isoformat()
     # (event, chunk_size=2800, role_arn=None, bucket_output=None):

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -3,7 +3,6 @@ import json
 import uuid
 
 from airflow.models.variable import Variable
-from airflow.models.xcom import LazyXComAccess
 from airflow.decorators import task
 from veda_data_pipeline.utils.s3_discovery import (
     s3_discovery_handler, EmptyFileListError
@@ -66,7 +65,7 @@ def get_files_task(payload, ti=None):
     payloads = payload if isinstance(payload, list) else [payload]
 
     for item in payloads:
-        if isinstance(item, LazyXComAccess):  # Dynamic task mapping case
+        if isinstance(item, list):  # Dynamic task mapping case
             payloads_xcom = item[0].pop("payload", [])
             base_payload = item[0]
         else:
@@ -88,7 +87,7 @@ def get_files_to_process(payload, ti=None):
     """Get files from S3 produced by the discovery task.
     Used as part of both the parallel_run_process_rasters and parallel_run_process_vectors tasks.
     """
-    if isinstance(payload, LazyXComAccess):  # if used as part of a dynamic task mapping
+    if isinstance(payload, list):  # if used as part of a dynamic task mapping
         payloads_xcom = payload[0].pop("payload", [])
         payload = payload[0]
     else:
@@ -111,7 +110,7 @@ def get_dataset_files_to_process(payload, ti=None):
 
     result = []
     for x in payload:
-        if isinstance(x, LazyXComAccess):  # if used as part of a dynamic task mapping
+        if isinstance(x, list):  # if used as part of a dynamic task mapping
             payloads_xcom = x[0].pop("payload", [])
             payload_0 = x[0]
         else:

--- a/dags/veda_data_pipeline/veda_stactools.py
+++ b/dags/veda_data_pipeline/veda_stactools.py
@@ -22,6 +22,7 @@ dag_args = {
     "catchup": False,
     "doc_md": dag_doc_md,
     "is_paused_upon_creation": False,
+    "schedule_interval": None,
 }
 
 template_dag_run_conf = {

--- a/dags/veda_data_pipeline/veda_stactools_noaa_hrrr.py
+++ b/dags/veda_data_pipeline/veda_stactools_noaa_hrrr.py
@@ -72,7 +72,7 @@ def get_stactools_dag(id, event={}):
     params_dag_run_conf = event or template_dag_run_conf
     with DAG(
         id,
-        schedule_interval=event.get("schedule"),
+        schedule_interval=event.get("schedule", None),
         params=params_dag_run_conf,
         **dag_args
     ) as dag:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   # Doesn't have ARM64 image
   # https://github.com/roribio/alpine-sqs
   celery-broker:
-    image: roribio16/alpine-sqs:latest
+    image: softwaremill/elasticmq:latest
     platform: linux/amd64
     expose:
       - 9324
@@ -122,7 +122,7 @@ services:
 
   airflow-worker:
     <<: *airflow-worker
-    command: airflow celery worker
+    command: uv run airflow celery worker
     # SQS does not support worker remote control commands.
     # We will ping celery broker from the worker to test healthcheck.
     healthcheck:

--- a/infrastructure/configuration/airflow.cfg
+++ b/infrastructure/configuration/airflow.cfg
@@ -60,4 +60,4 @@ remote_logging = true
 # Setting full_url_mode to false allows us to use multiple fields when storing connections
 # Source code: https://github.com/apache/airflow/blob/main/airflow/providers/amazon/aws/secrets/secrets_manager.py
 backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
-backend_kwargs = {"connections_prefix": "sm2a-dev/airflow/connections", "variables_prefix": "sm2a-dev/airflow/variables","connections_lookup_pattern": "_default$", "variables_lookup_pattern": "^aws_", "config_prefix": "sm2a-dev/airflow/config"}
+backend_kwargs = {"connections_prefix": "sm2a-sit/airflow/connections", "variables_prefix": "sm2a-sit/airflow/variables","connections_lookup_pattern": "_default$", "variables_lookup_pattern": "^aws_", "config_prefix": "sm2a-sit/airflow/config"}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -51,6 +51,7 @@ module "sma-base" {
   rds_allocated_storage          = tonumber(var.rds_allocated_storage)
   rds_max_allocated_storage      = tonumber(var.rds_max_allocated_storage)
   workers_logs_retention_days    = tonumber(var.workers_logs_retention_days)
+  airflow_version                = var.airflow_version
 
   extra_airflow_task_common_environment = [
     {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,7 +26,7 @@ module "rds_backups" {
 
 
 module "sma-base" {
-  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.10/self-managed-apache-airflow.zip"
+  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.11/self-managed-apache-airflow.zip"
   project                        = var.project_name
   airflow_db                     = var.airflow_db
   fernet_key                     = var.fernet_key

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -247,3 +247,8 @@ variable "lambda_dag_trigger_function_name" {
 variable ingest_api_keycloak_client_secret {
  type = string
 }
+
+variable "airflow_version" {
+  type    = string
+  default = "2.10.5"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Function and deployment code for producing cloud-optimized data p
 readme = "README.md"
 requires-python = ">=3.11.5, <3.12"
 dependencies = [
-    "apache-airflow==2.8.4",
+    "apache-airflow==2.10.5",
     "pytest>=8.3.5",
 ]
 


### PR DESCRIPTION
**Summary:** 

Airflow (+related libraries) version upgrade. This prompted some other changes and improvements, as several things broke with the updated libraries.
- old SQS image is outdated and had to be replaced
- switched to uv and dropped conda to fix library build issues
- example DAGs use outdated providers, I opted to delete instead of refactor
- `LazyXcomAccess` -> `LazyXcomSequence`
- stactools DAGs were scheduled by default - this has been fixed

~Manual step required to make deployment work with new version - `python scripts/run_task.py --vpc-id vpc-xxx --security-group xxx --task-definition xxx --cluster xxx--command 'db init'`~

^ No longer applies, instead we must set the `airflow_version` variable for SM2A - https://github.com/NASA-IMPACT/self-managed-apache-airflow/pull/23

## Testing/action items
- [x] SIT deployment tested (deploy works, but services require manual db upgrade)
- [x] tested raster ingestion with `veda-dataset-pipeline`
- [x] tested vector ingestion with `veda-vector-pipeline` - works, but SIT cannot connect to dev features DB to submit generated items