### PR TITLE
fix: update workflows to use full commit hash

### DIFF
--- a/.github/actions/terraform-deploy-sm2a/action.yml
+++ b/.github/actions/terraform-deploy-sm2a/action.yml
@@ -28,13 +28,13 @@ runs:
 
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: "3.11"
         cache: "pip"
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd #v1.4.0
       with:
         terraform_version: 1.3.10
 

--- a/.github/actions/terraform-deploy/action.yml
+++ b/.github/actions/terraform-deploy/action.yml
@@ -23,7 +23,7 @@ runs:
 
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: "3.10"
         cache: "pip"
@@ -52,7 +52,7 @@ runs:
         fi
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       with:
         terraform_version: 1.6.6
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,13 +53,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
         with:
           lfs: "true"
           submodules: "recursive"
-        
+
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 #v2.2.0
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: "veda-airflow-github-${{ needs.define-environment.outputs.env_name }}-deployment"

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b #v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 #v1.16.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}


### PR DESCRIPTION
**Summary:** Summary of changes

https://github.com/NASA-IMPACT/veda-architecture/issues/569

## Changes

* actions/setup-python@v5 pinned to [v5.4.0](https://github.com/actions/setup-python/commit/42375524e23c412d93fb67b49958b491fce71c38)
* hashicorp/setup-terraform@v1 pinned to [v1.4.0](https://github.com/hashicorp/setup-terraform/commit/ed3a0531877aca392eb870f440d9ae7aba83a6bd)
* actions/checkout@v3 pinned to v[3.6.0](https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744)
* aws-actions/configure-aws-credentials@v2 pinned to [v2.2.0](https://github.com/aws-actions/configure-aws-credentials/commit/5fd3084fc36e372ff1fff382a39b10d03659f355)
* actions/checkout@v4 pinned to [v4.2.2](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683)
* mathieudutour/github-tag-action@v6.2 pinned to [v6.2](https://github.com/mathieudutour/github-tag-action/commit/a22cf08638b34d5badda920f9daf6e72c477b07b)
* ncipollo/release-action@v1 pinned to [v1.16.0](https://github.com/ncipollo/release-action/commit/440c8c1cb0ed28b9f43e4d1d670870f059653174)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests