### PR TITLE
use event config to set invalidate_cloudfront

### DIFF
--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -76,7 +76,7 @@ def ingest_vector_task(payload):
 @task
 def invalidate_cloudfront(event: dict={}):
     import boto3
-    if not event.get("invalidate_cloudfront", False):
+    if not event.get("invalidate_cloudfront"):
         logging.info("Skipping cloudfront invalidation")
         return
 

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -74,9 +74,9 @@ def ingest_vector_task(payload):
 
 
 @task
-def invalidate_cloudfront(ti):
+def invalidate_cloudfront(event: dict={}):
     import boto3
-    if not ti.dag_run.conf['invalidate_cloudfront']:
+    if not event.get("invalidate_cloudfront", False):
         logging.info("Skipping cloudfront invalidation")
         return
 
@@ -117,7 +117,7 @@ def get_ingest_vector_dag(id: str, event: dict):
         end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
         discover = start >> discover_from_s3_task(event=event)
         get_files = get_files_task(payload=discover)
-        ingest_vector_task.expand(payload=get_files) >> invalidate_cloudfront() >> end
+        ingest_vector_task.expand(payload=get_files) >> invalidate_cloudfront(event=event) >> end
 
         return dag
 


### PR DESCRIPTION
## What
Use `invalidate_cloudfront` key in event instead of ti.conf.

The param is set in the template_dag_run_conf 
https://github.com/NASA-IMPACT/veda-data-airflow/blob/dev/dags/veda_data_pipeline/veda_vector_pipeline.py#L56

And the DAG event is constructed from either a schedule config or the template
https://github.com/NASA-IMPACT/veda-data-airflow/blob/dev/dags/veda_data_pipeline/veda_vector_pipeline.py#L125


## Why
There is no task instance config for scheduled DAGs so use event parameter

```
[2025-03-20, 21:36:17 UTC] {taskinstance.py:2731} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 444, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 414, in _execute_callable
    return execute_callable(context=context, **execute_callable_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/decorators/base.py", line 241, in execute
    return_value = super().execute(context)
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/operators/python.py", line 200, in execute
    return_value = self.execute_callable()
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/operators/python.py", line 217, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/dags/veda_data_pipeline/veda_vector_pipeline.py", line 79, in invalidate_cloudfront
    if not ti.dag_run.conf['invalidate_cloudfront']:
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'invalidate_cloudfront'
``` 