### PR TITLE
Fix/run conf airflow params dict

### DIFF
--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -1,6 +1,7 @@
 import pendulum
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.models.param import Param, ParamsDict
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
 
 from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task
@@ -54,7 +55,7 @@ template_dag_run_conf = {
     "filename_regex": "<file_regex>",
     "id_regex": "<id_regex>",
     "id_template": "<id_template_string>",
-    "datetime_range": "<year>|<month>|<day>",
+    "datetime_range": Param("year", type="string", enum=["year","month", "day"], description="<year|month|day>", default=""),
     "assets": {
         "<asset1_name>": {
             "title": "<asset_title>",
@@ -96,4 +97,4 @@ def get_discover_dag(id: str, event: dict):
 
 # Sending empty event because we rely on task instance (ti) for manula runs
 # and payload for scheduled runs
-get_discover_dag(id="veda_discover", event={})
+get_discover_dag(id="veda_discover", event=ParamsDict(template_dag_run_conf))

--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -75,7 +75,7 @@ def get_discover_dag(id: str, event: dict):
     with DAG(
             id,
             schedule_interval=event.get("schedule"),
-            params=event,
+            params=ParamsDict(event),
             **dag_args
     ) as dag:
         start = DummyOperator(task_id="Start", dag=dag)
@@ -97,4 +97,4 @@ def get_discover_dag(id: str, event: dict):
 
 # Sending empty event because we rely on task instance (ti) for manula runs
 # and payload for scheduled runs
-get_discover_dag(id="veda_discover", event=ParamsDict(template_dag_run_conf))
+get_discover_dag(id="veda_discover", event=template_dag_run_conf)

--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -49,13 +49,13 @@ dag_args = {
 }
 
 template_dag_run_conf = {
-    "collection": "<coll_name>",
+    "collection": Param("collection_name", type="string"),
     "bucket": "<bucket>",
     "prefix": "<prefix>/",
     "filename_regex": "<file_regex>",
     "id_regex": "<id_regex>",
     "id_template": "<id_template_string>",
-    "datetime_range": Param("year", type="string", enum=["year","month", "day"], description="<year|month|day>", default=""),
+    "datetime_range": Param(type="string", enum=["year","month", "day"], description="<year|month|day>", default=""),
     "assets": {
         "<asset1_name>": {
             "title": "<asset_title>",

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 import pendulum
-from airflow.models.param import Param
+from airflow.models.param import Param, ParamsDict
 from airflow.decorators import task
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
@@ -125,4 +125,4 @@ def get_ingest_vector_dag(id: str, event: dict):
 
 # Sending empty event because we rely on task instance (ti) for manual runs
 # and payload for scheduled runs
-get_ingest_vector_dag(id="veda_ingest_vector", event={})
+get_ingest_vector_dag(id="veda_ingest_vector", event=ParamsDict(template_dag_run_conf))

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -111,7 +111,7 @@ def get_ingest_vector_dag(id: str, event: dict):
     with DAG(
             id,
             schedule_interval=event.get("schedule", None),
-            params=event,
+            params=ParamsDict(event),
             **dag_args
     ) as dag:
         start = DummyOperator(task_id="Start", dag=dag)
@@ -125,4 +125,4 @@ def get_ingest_vector_dag(id: str, event: dict):
 
 # Sending empty event because we rely on task instance (ti) for manual runs
 # and payload for scheduled runs
-get_ingest_vector_dag(id="veda_ingest_vector", event=ParamsDict(template_dag_run_conf))
+get_ingest_vector_dag(id="veda_ingest_vector", event=template_dag_run_conf)


### PR DESCRIPTION
## What
Serialize airflow Params to dict

```
>>> from airflow.models.param import Param, ParamsDict
>>> templ = {
... "collection": Param("collection_name", type="string"),
... "datetime_range": Param(type="string", enum=["year","month", "day"], description="<year|month|day>", default=""),
... "filename_regex": "<file_regex>"
... }
>>> 
>>> print(templ)
{'collection': <airflow.models.param.Param object at 0x102e907c0>, 'datetime_range': <airflow.models.param.Param object at 0x102f01b20>, 'filename_regex': '<file_regex>'}
>>> print(ParamsDict(templ))
{'collection': 'collection_name', 'datetime_range': None, 'filename_regex': '<file_regex>'}
```