### PR TITLE
Fix/batch failure handling

### DIFF
--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -3,7 +3,6 @@ import json
 import uuid
 
 from airflow.models.variable import Variable
-from airflow.models.xcom import LazyXComAccess
 from airflow.decorators import task
 from veda_data_pipeline.utils.s3_discovery import (
     s3_discovery_handler, EmptyFileListError
@@ -62,7 +61,7 @@ def get_files_task(payload, ti=None):
     payloads = payload if isinstance(payload, list) else [payload]
 
     for item in payloads:
-        if isinstance(item, LazyXComAccess):  # Dynamic task mapping case
+        if isinstance(item, list):  # Dynamic task mapping case
             payloads_xcom = item[0].pop("payload", [])
             base_payload = item[0]
         else:
@@ -84,7 +83,7 @@ def get_files_to_process(payload, ti=None):
     """Get files from S3 produced by the discovery task.
     Used as part of both the parallel_run_process_rasters and parallel_run_process_vectors tasks.
     """
-    if isinstance(payload, LazyXComAccess):  # if used as part of a dynamic task mapping
+    if isinstance(payload, list):  # if used as part of a dynamic task mapping
         payloads_xcom = payload[0].pop("payload", [])
         payload = payload[0]
     else:
@@ -107,7 +106,7 @@ def get_dataset_files_to_process(payload, ti=None):
 
     result = []
     for x in payload:
-        if isinstance(x, LazyXComAccess):  # if used as part of a dynamic task mapping
+        if isinstance(x, list):  # if used as part of a dynamic task mapping
             payloads_xcom = x[0].pop("payload", [])
             payload_0 = x[0]
         else:

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 import json
 import logging
 from copy import deepcopy
@@ -59,4 +58,13 @@ def build_stac_task(payload):
     from veda_data_pipeline.utils.build_stac.handler import stac_handler
     airflow_vars_json = Variable.get("aws_dags_variables", deserialize_json=True)
     event_bucket = airflow_vars_json.get("EVENT_BUCKET")
+
+    """ returns: "payload": {
+            "success_event_key": success_key,
+            "failed_event_key": dead_letter_key,
+            "status": {
+                "successes": len(payload_success),
+                "failures": len(payload_failures),
+            },
+        }"""
     return stac_handler(payload_src=payload, bucket_output=event_bucket)

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -115,11 +115,13 @@ def stac_handler(payload_src: dict, bucket_output):
         key=key, payload_success=payload_success, payload_failures=payload_failures
     )
 
-    # Silent dead letters are nice, but we want the Airflow UI to quickly alert us if something went wrong.
     if len(payload_failures) != 0:
-        raise ValueError(
+        print(ValueError(
             f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
-        )
+        ))
+
+        print(f"Failures encounterd for STAC item ids {[failure.get('item_id', None) for failure in payload_failures]}")
+        print(f"Unique errors reported in failures {set([failure.get('error', None) for failure in payload_failures])}")
 
     return {
         "payload": {

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -5,6 +5,11 @@ from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_
 from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
 from veda_data_pipeline.groups.collection_group import collection_task_group
 from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset
+from veda_data_pipeline.groups.failure_management_group import notify_failure, review_build_stac_failures
+import smart_open
+import json
+
+from airflow.decorators import task
 
 template_dag_run_conf = {
     "collection": "<collection-id>",
@@ -44,13 +49,32 @@ dag_args = {
     "tags": ["collection", "discovery"],
 }
 
+@task.branch
+def branch_on_build_success_task(payload) -> str:
+    if payload['payload']['status']['failures'] > 0:
+        return "review_build_stac_failures"
+    else:
+        return "submit_to_stac_ingestor_task"
+
 with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as dag:
     start = EmptyOperator(task_id="start")
     end = EmptyOperator(task_id="end")
 
     mutated_payloads = start >> collection_task_group() >> remove_thumbnail_asset()
+
     discovery_items = extract_discovery_items_from_payload(payload=mutated_payloads)
     discover = discover_from_s3_task.partial(payload=mutated_payloads).expand(event=discovery_items)
     get_files = get_files_task(payload=discover)
     build_stac = build_stac_task.expand(payload=get_files)
-    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> end
+    branch_on_build_success = branch_on_build_success_task.expand(payload=build_stac)
+    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) # TODO review trigger
+    review = review_build_stac_failures.expand(built_stac_report=build_stac)
+    filtered_stac = review["filtered_stac"]
+    submit_filtered_stac = submit_to_stac_ingestor_task(built_stac=filtered_stac)
+    notify = notify_failure(status="failed", emoji="red-circle", failed_items=review["failed_items"])
+
+    branch_on_build_success >> [submit_stac, review]
+    review >> notify >> end
+    review >> submit_filtered_stac >> end
+    submit_stac >> end
+


### PR DESCRIPTION
Branched off of #327

Overview:

build_stac never fails (unless something _really_ bad happens), failures are reported in output.

If a batch fails, the branch catches it. Non-failing batches continue normally.

Failing batches go to a `review` step. Valid files are split off to be submitted normally, failing files are reported to a `notify` step. **This part is not implemented yet, but the tasks are defined as placeholders**


![image](https://github.com/user-attachments/assets/dfdfa9d5-0b63-40ca-af3e-c509ad556217)

