### PR TITLE
fix(generate-dags): allow empty string in optional datetime range enums

### DIFF
--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -55,7 +55,7 @@ template_dag_run_conf = {
     "filename_regex": "<file_regex>",
     "id_regex": "<id_regex>",
     "id_template": "<id_template_string>",
-    "datetime_range": Param(type="string", enum=["year","month", "day", None], description="<year|month|day>", default=None),
+    "datetime_range": Param(type="string", enum=["year","month", "day", ""], description="<year|month|day>", default=""),
     "assets": {
         "<asset1_name>": {
             "title": "<asset_title>",

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -45,7 +45,7 @@ template_dag_run_conf = {
     "bucket": "<bucket>",
     "filename_regex": "<filename_regex>",
     "id_template": "<id_template_prefix>-{}",
-    "datetime_range": Param(type="string", enum=["month", "day", None], description="<month|day>", default=None),
+    "datetime_range": Param(type="string", enum=["month", "day", ""], description="<month|day>", default=""),
     "vector": Param(True, type="boolean"),
     "x_possible": "<x_column_name>",
     "y_possible": "<y_column_name>",


### PR DESCRIPTION
## What

Try to support an optional airflow Param with ENUMs list. `None` is not type string so an empty string may get through airflow and hopefully will be properly handled in the DAG runtime