### PR TITLE
fix: when transfer is false in a promotion config, do not transfer files. when files are up to date, continue 

### DIFF
--- a/dags/veda_data_pipeline/utils/transfer.py
+++ b/dags/veda_data_pipeline/utils/transfer.py
@@ -42,12 +42,15 @@ def get_matching_files(s3_client, bucket, prefix, regex_pattern):
 
 
 def transfer_files_within_s3(
-    s3_client, origin_bucket, matching_files, destination_bucket, collection
+    s3_client, origin_bucket, matching_files, destination_bucket, collection, transfer=True
 ):
+    if not transfer:
+        print(f"Transfer is disabled. Would have copied {len(matching_files)} files from {origin_bucket} to {destination_bucket}")
+        return
+
     transfer_exceptions = False
     for file_key in matching_files:
         filename = file_key.split("/")[-1]
-        # print(f"Transferring file: {filename}")
         target_key = f"{collection}/{filename}"
         copy_source = {"Bucket": origin_bucket, "Key": file_key}
 
@@ -91,6 +94,7 @@ def data_transfer_handler(event, role_arn=None):
     filename_regex = event.get("filename_regex")
     target_bucket = event.get("target_bucket")
     collection = event.get("collection")
+    transfer = event.get("transfer")
 
     kwargs = assume_role(role_arn=role_arn) if role_arn else {}
     s3client = boto3.client("s3", **kwargs)
@@ -111,6 +115,7 @@ def data_transfer_handler(event, role_arn=None):
             matching_files=matching_files,
             destination_bucket=target_bucket,
             collection=collection,
+            transfer=transfer
         )
     else:
         print(

--- a/dags/veda_data_pipeline/utils/transfer.py
+++ b/dags/veda_data_pipeline/utils/transfer.py
@@ -56,6 +56,7 @@ def transfer_files_within_s3(
 
         # We can use the etag to check if the file has already been copied and avoid duplication of effort
         # by using the CopySourceIfNoneMatch parameter below.
+        target_etag = None
         try:
             target_metadata = s3_client.head_object(
                 Bucket=destination_bucket, Key=target_key
@@ -76,6 +77,11 @@ def transfer_files_within_s3(
                     Bucket=destination_bucket,
                     Key=target_key
                 )
+            elif err.response["Error"]["Code"] == "PreconditionFailed":  # 412 error
+                # File is already up to date, skip copying
+                print(f"File {filename} is already up to date, skipping")
+                print(f"CopySourceIfNoneMatch: {target_etag}. Skip copy: object is unchanged (ETag matches).")
+                continue
             else:
                 msg = f"ClientError copying {filename=} {err=}"
                 print(msg)

--- a/dags/veda_data_pipeline/utils/transfer.py
+++ b/dags/veda_data_pipeline/utils/transfer.py
@@ -42,12 +42,8 @@ def get_matching_files(s3_client, bucket, prefix, regex_pattern):
 
 
 def transfer_files_within_s3(
-    s3_client, origin_bucket, matching_files, destination_bucket, collection, transfer
+    s3_client, origin_bucket, matching_files, destination_bucket, collection
 ):
-    if not transfer:
-        print(f"Transfer is disabled. Would have copied {len(matching_files)} files from {origin_bucket} to {destination_bucket}")
-        return
-
     transfer_exceptions = False
     for file_key in matching_files:
         filename = file_key.split("/")[-1]
@@ -100,7 +96,6 @@ def data_transfer_handler(event, role_arn=None):
     filename_regex = event.get("filename_regex")
     target_bucket = event.get("target_bucket")
     collection = event.get("collection")
-    transfer = event.get("transfer")
 
     kwargs = assume_role(role_arn=role_arn) if role_arn else {}
     s3client = boto3.client("s3", **kwargs)
@@ -121,7 +116,6 @@ def data_transfer_handler(event, role_arn=None):
             matching_files=matching_files,
             destination_bucket=target_bucket,
             collection=collection,
-            transfer=transfer
         )
     else:
         print(

--- a/dags/veda_data_pipeline/utils/transfer.py
+++ b/dags/veda_data_pipeline/utils/transfer.py
@@ -42,7 +42,7 @@ def get_matching_files(s3_client, bucket, prefix, regex_pattern):
 
 
 def transfer_files_within_s3(
-    s3_client, origin_bucket, matching_files, destination_bucket, collection, transfer=True
+    s3_client, origin_bucket, matching_files, destination_bucket, collection, transfer
 ):
     if not transfer:
         print(f"Transfer is disabled. Would have copied {len(matching_files)} files from {origin_bucket} to {destination_bucket}")

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -74,20 +74,26 @@ template_dag_run_conf = {
 def transfer_assets_to_production_bucket(ti=None, payload={}):
     # merge collection id into payload, then transfer data
     payload["collection"] = ti.dag_run.conf.get("collection")
+    transfer = payload.get("transfer", ti.dag_run.conf.get("transfer", True))
+
     config = {
         **payload,
         "origin_bucket": payload.get("bucket", ti.dag_run.conf.get("origin_bucket", "veda-data-store")),
         "origin_prefix": payload.get("prefix", ti.dag_run.conf.get("origin_prefix", "s3-prefix/")),
         "target_bucket": payload.get("target_bucket", ti.dag_run.conf.get("target_bucket", "veda-data-store")),
         "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", False)),
-        "transfer": payload.get("transfer", ti.dag_run.conf.get("transfer", True)),
     }
 
-    transfer_data(payload=config)
-    # if transfer complete, update discovery payload to reflect new bucket
-    payload.update({"bucket": "veda-data-store"})
-    payload.update({"prefix": payload.get("collection")+"/"})
-    return payload
+    if not transfer:
+      print(f"Transfer is disabled. Skipping transfer.")
+      return payload
+    else:
+        transfer_data(payload=config)
+
+        # if transfer complete, update discovery payload to reflect new bucket
+        payload.update({"bucket": "veda-data-store"})
+        payload.update({"prefix": payload.get("collection")+"/"})
+        return payload
 
 with DAG("veda_promotion_pipeline", params=template_dag_run_conf, **dag_args) as dag:
     # ECS dependency variable

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -80,7 +80,7 @@ def transfer_assets_to_production_bucket(ti=None, payload={}):
         "origin_prefix": payload.get("prefix", ti.dag_run.conf.get("origin_prefix", "s3-prefix/")),
         "target_bucket": payload.get("target_bucket", ti.dag_run.conf.get("target_bucket", "veda-data-store")),
         "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", False)),
-        "transfer": ti.dag_run.conf.get("transfer"),
+        "transfer": payload.get("transfer", ti.dag_run.conf.get("transfer", False)),
     }
     transfer_data(payload=config)
     # if transfer complete, update discovery payload to reflect new bucket

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -82,6 +82,7 @@ def transfer_assets_to_production_bucket(ti=None, payload={}):
         "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", False)),
         "transfer": payload.get("transfer", ti.dag_run.conf.get("transfer", True)),
     }
+
     transfer_data(payload=config)
     # if transfer complete, update discovery payload to reflect new bucket
     payload.update({"bucket": "veda-data-store"})
@@ -95,8 +96,8 @@ with DAG("veda_promotion_pipeline", params=template_dag_run_conf, **dag_args) as
     end = EmptyOperator(task_id="end", dag=dag)
 
     collection_grp = collection_task_group()
-    mutate_payload_task = remove_thumbnail_asset()
-    extract_from_payload = extract_discovery_items_from_payload()
+    mutate_payload_task = remove_thumbnail_asset(ti=None)
+    extract_from_payload = extract_discovery_items_from_payload(ti=None)
 
     # asset transfer to production bucket
     transfer_task = transfer_assets_to_production_bucket.expand(payload=extract_from_payload)

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -3,6 +3,8 @@ from airflow import DAG
 from airflow.decorators import task
 from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
 from airflow.models.variable import Variable
+from airflow.models.param import Param
+
 import json
 from veda_data_pipeline.groups.collection_group import collection_task_group
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_dataset_files_to_process
@@ -18,23 +20,24 @@ This will mutate the payload, so that item references will target the new asset 
 - This DAG can run with the following configuration <br>
 ```json
 {
-    "collection": "collection-id", 
-    "data_type": "cog", 
-    "description": "collection description", 
-    "discovery_items": 
+    "collection": "collection-id",
+    "data_type": "cog",
+    "description": "collection description",
+    "discovery_items":
         [
             {
-                "bucket": "veda-data-store-staging", 
-                "datetime_range": "year", 
-                "discovery": "s3", 
-                "filename_regex": "^(.*).tif$", 
+                "bucket": "veda-data-store-staging",
+                "datetime_range": "year",
+                "discovery": "s3",
+                "filename_regex": "^(.*).tif$",
                 "prefix": "example-prefix/"
             }
-        ], 
-    "is_periodic": true, 
-    "license": "collection-LICENSE", 
-    "time_density": "year", 
-    "title": "collection-title"
+        ],
+    "is_periodic": true,
+    "license": "collection-LICENSE",
+    "time_density": "year",
+    "title": "collection-title",
+    "transfer": "false"
 }
 ```
 """
@@ -51,33 +54,33 @@ template_dag_run_conf = {
     "collection": "<collection-id>",
     "data_type": "cog",
     "description": "<collection-description>",
-    "discovery_items":
-        [
-            {
-                "bucket": "<bucket-name>",
-                "datetime_range": "<range>",
-                "discovery": "s3",
-                "filename_regex": "<regex>",
-                "prefix": "<example-prefix/>"
-            }
-        ],
+    "discovery_items": [
+        {
+            "bucket": "<bucket-name>",
+            "datetime_range": "<range>",
+            "discovery": "s3",
+            "filename_regex": "<regex>",
+            "prefix": "<example-prefix/>"
+        }
+    ],
     "is_periodic": "<true|false>",
     "license": "<collection-LICENSE>",
     "time_density": "<time-density>",
     "title": "<collection-title>",
-    "transfer": "<true|false> # transfer assets to production bucket if true (false by default)", 
+    "transfer": Param(False, type="boolean", description="Transfer assets to production bucket if true (false by default)"),
 }
 
 @task(max_active_tis_per_dag=3)
 def transfer_assets_to_production_bucket(ti=None, payload={}):
     # merge collection id into payload, then transfer data
-    payload['collection'] = ti.dag_run.conf.get("collection")
+    payload["collection"] = ti.dag_run.conf.get("collection")
     config = {
         **payload,
         "origin_bucket": payload.get("bucket", ti.dag_run.conf.get("origin_bucket", "veda-data-store")),
         "origin_prefix": payload.get("prefix", ti.dag_run.conf.get("origin_prefix", "s3-prefix/")),
         "target_bucket": payload.get("target_bucket", ti.dag_run.conf.get("target_bucket", "veda-data-store")),
         "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", False)),
+        "transfer": ti.dag_run.conf.get("transfer"),
     }
     transfer_data(payload=config)
     # if transfer complete, update discovery payload to reflect new bucket

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -67,7 +67,7 @@ template_dag_run_conf = {
     "license": "<collection-LICENSE>",
     "time_density": "<time-density>",
     "title": "<collection-title>",
-    "transfer": Param(False, type="boolean", description="Transfer assets to production bucket if true (false by default)"),
+    "transfer": Param(True, type="boolean", description="Transfer assets to production bucket if true (true by default)"),
 }
 
 @task(max_active_tis_per_dag=3)
@@ -80,7 +80,7 @@ def transfer_assets_to_production_bucket(ti=None, payload={}):
         "origin_prefix": payload.get("prefix", ti.dag_run.conf.get("origin_prefix", "s3-prefix/")),
         "target_bucket": payload.get("target_bucket", ti.dag_run.conf.get("target_bucket", "veda-data-store")),
         "dry_run": payload.get("dry_run", ti.dag_run.conf.get("dry_run", False)),
-        "transfer": payload.get("transfer", ti.dag_run.conf.get("transfer", False)),
+        "transfer": payload.get("transfer", ti.dag_run.conf.get("transfer", True)),
     }
     transfer_data(payload=config)
     # if transfer complete, update discovery payload to reflect new bucket

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -1,7 +1,7 @@
 import pendulum
 from airflow import DAG
 from airflow.decorators import task
-from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.models.variable import Variable
 from airflow.models.param import Param
 
@@ -44,7 +44,7 @@ This will mutate the payload, so that item references will target the new asset 
 
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
-    "schedule_interval": None,
+    "schedule": None,
     "catchup": False,
     "doc_md": dag_doc_md,
     "tags": ["collection", "discovery"],
@@ -96,8 +96,8 @@ with DAG("veda_promotion_pipeline", params=template_dag_run_conf, **dag_args) as
     end = EmptyOperator(task_id="end", dag=dag)
 
     collection_grp = collection_task_group()
-    mutate_payload_task = remove_thumbnail_asset(ti=None)
-    extract_from_payload = extract_discovery_items_from_payload(ti=None)
+    mutate_payload_task = remove_thumbnail_asset()
+    extract_from_payload = extract_discovery_items_from_payload()
 
     # asset transfer to production bucket
     transfer_task = transfer_assets_to_production_bucket.expand(payload=extract_from_payload)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 apache-airflow
 coverage
+moto>=4.2.13

--- a/tests/test_promotion_pipeline.py
+++ b/tests/test_promotion_pipeline.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import Mock, patch
+from dags.veda_data_pipeline.veda_promotion_pipeline import transfer_assets_to_production_bucket
+
+@pytest.fixture
+def mock_task_instance():
+    ti = Mock()
+    ti.dag_run.conf = {
+        "collection": "test-collection",
+        "origin_bucket": "test-origin-bucket",
+        "origin_prefix": "test-prefix/",
+        "target_bucket": "test-target-bucket",
+        "dry_run": False,
+    }
+    return ti
+
+def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance):
+    """Test that when transfer is False, payload is updated but no transfer occurs"""
+    mock_task_instance.dag_run.conf["transfer"] = False
+
+    with patch("dags.veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer:
+        payload = {
+            "bucket": "staging-bucket",
+            "prefix": "staging-prefix/",
+        }
+
+        result = transfer_assets_to_production_bucket(ti=mock_task_instance, payload=payload)
+
+        # Verify transfer_data was not called
+        mock_transfer.assert_not_called()
+
+        # Verify payload was updated correctly
+        assert result["bucket"] == "veda-data-store"
+        assert result["prefix"] == "test-collection/"
+
+def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance):
+    """Test that when transfer is True, payload is updated and transfer occurs"""
+    mock_task_instance.dag_run.conf["transfer"] = True
+
+    with patch("dags.veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer:
+        payload = {
+            "bucket": "staging-bucket",
+            "prefix": "staging-prefix/",
+        }
+
+        result = transfer_assets_to_production_bucket(ti=mock_task_instance, payload=payload)
+
+        mock_transfer.assert_called_once()
+        call_args = mock_transfer.call_args[1]["payload"]
+        assert call_args["transfer"] is True
+        assert call_args["origin_bucket"] == "staging-bucket"
+        assert call_args["origin_prefix"] == "staging-prefix/"
+        assert call_args["target_bucket"] == "test-target-bucket"
+        assert call_args["collection"] == "test-collection"
+
+        assert result["bucket"] == "veda-data-store"
+        assert result["prefix"] == "test-collection/"
+
+def test_transfer_assets_to_production_bucket_transfer_default(mock_task_instance):
+    """Test that when transfer is not specified, it defaults to False"""
+
+    with patch("dags.veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer:
+        payload = {
+            "bucket": "staging-bucket",
+            "prefix": "staging-prefix/",
+        }
+
+        result = transfer_assets_to_production_bucket(ti=mock_task_instance, payload=payload)
+
+        mock_transfer.assert_not_called()
+
+        assert result["bucket"] == "veda-data-store"
+        assert result["prefix"] == "test-collection/"

--- a/tests/test_promotion_pipeline.py
+++ b/tests/test_promotion_pipeline.py
@@ -71,8 +71,8 @@ def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance,
 
         response = s3.list_objects_v2(Bucket="test-target-bucket")
         assert "Contents" not in response
-        assert result["bucket"] == "veda-data-store"
-        assert result["prefix"] == "test-collection/"
+        assert result["bucket"] == "test-origin-bucket"
+        assert result["prefix"] == "test-prefix/"
 
 def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance, mock_aws_vars, s3):
     """Test that when transfer is True, payload is updated and transfer occurs"""

--- a/tests/test_promotion_pipeline.py
+++ b/tests/test_promotion_pipeline.py
@@ -46,7 +46,7 @@ def mock_s3_client():
         ]
     }
 
-    # Mock head_object to return a 404 error
+    # Mock head_object to return a 404 error by default
     def head_object_side_effect(**kwargs):
         error_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
         raise ClientError(error_response, 'HeadObject')
@@ -146,5 +146,42 @@ def test_transfer_assets_to_production_bucket_transfer_default(mock_task_instanc
         assert call_args["target_bucket"] == "test-target-bucket"
         assert call_args["collection"] == "test-collection"
 
+        assert result["bucket"] == "veda-data-store"
+        assert result["prefix"] == "test-collection/"
+
+def test_transfer_assets_to_production_bucket_412_error(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
+    """Test that when a file already exists with the same ETag (412 error), no error is raised"""
+    mock_task_instance.dag_run.conf["transfer"] = True
+
+    def head_object_side_effect_412(**kwargs):
+        return {'ETag': '"test-etag"'}
+
+    mock_s3_client.head_object.side_effect = head_object_side_effect_412
+
+    def copy_object_side_effect(**kwargs):
+        error_response = {'Error': {'Code': 'PreconditionFailed', 'Message': 'Precondition Failed'}}
+        raise ClientError(error_response, 'CopyObject')
+
+    mock_s3_client.copy_object.side_effect = copy_object_side_effect
+
+    with patch("dags.veda_data_pipeline.veda_promotion_pipeline.transfer_data") as mock_transfer, \
+         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
+         patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.side_effect = lambda service, **kwargs: {
+            'sts': mock_sts_client,
+            's3': mock_s3_client
+        }[service]
+
+        payload = {
+            "bucket": "staging-bucket",
+            "prefix": "staging-prefix/",
+            "filename_regex": r"^.*\.tif$",
+            "transfer": True
+        }
+
+        task_func = transfer_assets_to_production_bucket.function
+        result = task_func(ti=mock_task_instance, payload=payload)
+
+        mock_transfer.assert_called_once()
         assert result["bucket"] == "veda-data-store"
         assert result["prefix"] == "test-collection/"

--- a/tests/test_promotion_pipeline.py
+++ b/tests/test_promotion_pipeline.py
@@ -1,6 +1,9 @@
 import pytest
 from unittest.mock import Mock, patch
 from dags.veda_data_pipeline.veda_promotion_pipeline import transfer_assets_to_production_bucket
+import json
+import boto3
+from botocore.exceptions import ClientError
 
 @pytest.fixture
 def mock_task_instance():
@@ -11,20 +14,68 @@ def mock_task_instance():
         "origin_prefix": "test-prefix/",
         "target_bucket": "test-target-bucket",
         "dry_run": False,
+        "filename_regex": r"^.*\.tif$"
     }
     return ti
 
-def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance):
+@pytest.fixture
+def mock_aws_vars():
+    return {
+        "ASSUME_ROLE_WRITE_ARN": "arn:aws:iam::123456789012:role/test-role"
+    }
+
+@pytest.fixture
+def mock_sts_client():
+    mock_client = Mock()
+    mock_client.assume_role.return_value = {
+        'Credentials': {
+            'AccessKeyId': 'test-access-key',
+            'SecretAccessKey': 'test-secret-key',
+            'SessionToken': 'test-session-token'
+        }
+    }
+    return mock_client
+
+@pytest.fixture
+def mock_s3_client():
+    mock_client = Mock()
+    mock_client.list_objects_v2.return_value = {
+        'Contents': [
+            {'Key': 'staging-prefix/file1.tif'},
+            {'Key': 'staging-prefix/file2.tif'}
+        ]
+    }
+
+    # Mock head_object to return a 404 error
+    def head_object_side_effect(**kwargs):
+        error_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
+        raise ClientError(error_response, 'HeadObject')
+
+    mock_client.head_object.side_effect = head_object_side_effect
+    mock_client.exceptions.ClientError = ClientError
+    return mock_client
+
+def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
     """Test that when transfer is False, payload is updated but no transfer occurs"""
     mock_task_instance.dag_run.conf["transfer"] = False
 
-    with patch("dags.veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer:
+    with patch("veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer, \
+         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
+         patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.side_effect = lambda service, **kwargs: {
+            'sts': mock_sts_client,
+            's3': mock_s3_client
+        }[service]
+
         payload = {
             "bucket": "staging-bucket",
             "prefix": "staging-prefix/",
+            "filename_regex": r"^.*\.tif$",
+            "transfer": False
         }
 
-        result = transfer_assets_to_production_bucket(ti=mock_task_instance, payload=payload)
+        task_func = transfer_assets_to_production_bucket.function
+        result = task_func(ti=mock_task_instance, payload=payload)
 
         # Verify transfer_data was not called
         mock_transfer.assert_not_called()
@@ -33,17 +84,27 @@ def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance)
         assert result["bucket"] == "veda-data-store"
         assert result["prefix"] == "test-collection/"
 
-def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance):
+def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
     """Test that when transfer is True, payload is updated and transfer occurs"""
     mock_task_instance.dag_run.conf["transfer"] = True
 
-    with patch("dags.veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer:
+    with patch("dags.veda_data_pipeline.veda_promotion_pipeline.transfer_data") as mock_transfer, \
+         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
+         patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.side_effect = lambda service, **kwargs: {
+            'sts': mock_sts_client,
+            's3': mock_s3_client
+        }[service]
+
         payload = {
             "bucket": "staging-bucket",
             "prefix": "staging-prefix/",
+            "filename_regex": r"^.*\.tif$",
+            "transfer": True
         }
 
-        result = transfer_assets_to_production_bucket(ti=mock_task_instance, payload=payload)
+        task_func = transfer_assets_to_production_bucket.function
+        result = task_func(ti=mock_task_instance, payload=payload)
 
         mock_transfer.assert_called_once()
         call_args = mock_transfer.call_args[1]["payload"]
@@ -56,16 +117,26 @@ def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance):
         assert result["bucket"] == "veda-data-store"
         assert result["prefix"] == "test-collection/"
 
-def test_transfer_assets_to_production_bucket_transfer_default(mock_task_instance):
+def test_transfer_assets_to_production_bucket_transfer_default(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
     """Test that when transfer is not specified, it defaults to True"""
 
-    with patch("dags.veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer:
+    with patch("dags.veda_data_pipeline.veda_promotion_pipeline.transfer_data") as mock_transfer, \
+         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
+         patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.side_effect = lambda service, **kwargs: {
+            'sts': mock_sts_client,
+            's3': mock_s3_client
+        }[service]
+
         payload = {
             "bucket": "staging-bucket",
             "prefix": "staging-prefix/",
+            "filename_regex": r"^.*\.tif$",
+            "transfer": True
         }
 
-        result = transfer_assets_to_production_bucket(ti=mock_task_instance, payload=payload)
+        task_func = transfer_assets_to_production_bucket.function
+        result = task_func(ti=mock_task_instance, payload=payload)
 
         mock_transfer.assert_called_once()
         call_args = mock_transfer.call_args[1]["payload"]

--- a/tests/test_promotion_pipeline.py
+++ b/tests/test_promotion_pipeline.py
@@ -57,7 +57,7 @@ def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance):
         assert result["prefix"] == "test-collection/"
 
 def test_transfer_assets_to_production_bucket_transfer_default(mock_task_instance):
-    """Test that when transfer is not specified, it defaults to False"""
+    """Test that when transfer is not specified, it defaults to True"""
 
     with patch("dags.veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer:
         payload = {
@@ -67,7 +67,13 @@ def test_transfer_assets_to_production_bucket_transfer_default(mock_task_instanc
 
         result = transfer_assets_to_production_bucket(ti=mock_task_instance, payload=payload)
 
-        mock_transfer.assert_not_called()
+        mock_transfer.assert_called_once()
+        call_args = mock_transfer.call_args[1]["payload"]
+        assert call_args["transfer"] is True
+        assert call_args["origin_bucket"] == "staging-bucket"
+        assert call_args["origin_prefix"] == "staging-prefix/"
+        assert call_args["target_bucket"] == "test-target-bucket"
+        assert call_args["collection"] == "test-collection"
 
         assert result["bucket"] == "veda-data-store"
         assert result["prefix"] == "test-collection/"

--- a/tests/test_promotion_pipeline.py
+++ b/tests/test_promotion_pipeline.py
@@ -1,9 +1,11 @@
+import boto3
+import json
+import os
 import pytest
+
+from moto import mock_s3, mock_sts
 from unittest.mock import Mock, patch
 from dags.veda_data_pipeline.veda_promotion_pipeline import transfer_assets_to_production_bucket
-import json
-import boto3
-from botocore.exceptions import ClientError
 
 @pytest.fixture
 def mock_task_instance():
@@ -25,51 +27,41 @@ def mock_aws_vars():
     }
 
 @pytest.fixture
-def mock_sts_client():
-    mock_client = Mock()
-    mock_client.assume_role.return_value = {
-        'Credentials': {
-            'AccessKeyId': 'test-access-key',
-            'SecretAccessKey': 'test-secret-key',
-            'SessionToken': 'test-session-token'
-        }
-    }
-    return mock_client
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
 
 @pytest.fixture
-def mock_s3_client():
-    mock_client = Mock()
-    mock_client.list_objects_v2.return_value = {
-        'Contents': [
-            {'Key': 'staging-prefix/file1.tif'},
-            {'Key': 'staging-prefix/file2.tif'}
-        ]
-    }
+def s3():
+    with mock_s3(), mock_sts():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        # Create test buckets
+        s3.create_bucket(Bucket="test-origin-bucket")
+        s3.create_bucket(Bucket="test-target-bucket")
 
-    # Mock head_object to return a 404 error by default
-    def head_object_side_effect(**kwargs):
-        error_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
-        raise ClientError(error_response, 'HeadObject')
+        s3.put_object(
+            Bucket="test-origin-bucket",
+            Key="test-prefix/file1.tif",
+            Body="test content"
+        )
+        s3.put_object(
+            Bucket="test-origin-bucket",
+            Key="test-prefix/file2.tif",
+            Body="test content"
+        )
+        yield s3
 
-    mock_client.head_object.side_effect = head_object_side_effect
-    mock_client.exceptions.ClientError = ClientError
-    return mock_client
-
-def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
+def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance, mock_aws_vars, s3):
     """Test that when transfer is False, payload is updated but no transfer occurs"""
     mock_task_instance.dag_run.conf["transfer"] = False
 
-    with patch("veda_data_pipeline.groups.transfer_group.transfer_data") as mock_transfer, \
-         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
-         patch("boto3.client") as mock_boto3_client:
-        mock_boto3_client.side_effect = lambda service, **kwargs: {
-            'sts': mock_sts_client,
-            's3': mock_s3_client
-        }[service]
-
+    with patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)):
         payload = {
-            "bucket": "staging-bucket",
-            "prefix": "staging-prefix/",
+            "bucket": "test-origin-bucket",
+            "prefix": "test-prefix/",
             "filename_regex": r"^.*\.tif$",
             "transfer": False
         }
@@ -77,28 +69,19 @@ def test_transfer_assets_to_production_bucket_transfer_false(mock_task_instance,
         task_func = transfer_assets_to_production_bucket.function
         result = task_func(ti=mock_task_instance, payload=payload)
 
-        # Verify transfer_data was not called
-        mock_transfer.assert_not_called()
-
-        # Verify payload was updated correctly
+        response = s3.list_objects_v2(Bucket="test-target-bucket")
+        assert "Contents" not in response
         assert result["bucket"] == "veda-data-store"
         assert result["prefix"] == "test-collection/"
 
-def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
+def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance, mock_aws_vars, s3):
     """Test that when transfer is True, payload is updated and transfer occurs"""
     mock_task_instance.dag_run.conf["transfer"] = True
 
-    with patch("dags.veda_data_pipeline.veda_promotion_pipeline.transfer_data") as mock_transfer, \
-         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
-         patch("boto3.client") as mock_boto3_client:
-        mock_boto3_client.side_effect = lambda service, **kwargs: {
-            'sts': mock_sts_client,
-            's3': mock_s3_client
-        }[service]
-
+    with patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)):
         payload = {
-            "bucket": "staging-bucket",
-            "prefix": "staging-prefix/",
+            "bucket": "test-origin-bucket",
+            "prefix": "test-prefix/",
             "filename_regex": r"^.*\.tif$",
             "transfer": True
         }
@@ -106,75 +89,26 @@ def test_transfer_assets_to_production_bucket_transfer_true(mock_task_instance, 
         task_func = transfer_assets_to_production_bucket.function
         result = task_func(ti=mock_task_instance, payload=payload)
 
-        mock_transfer.assert_called_once()
-        call_args = mock_transfer.call_args[1]["payload"]
-        assert call_args["transfer"] is True
-        assert call_args["origin_bucket"] == "staging-bucket"
-        assert call_args["origin_prefix"] == "staging-prefix/"
-        assert call_args["target_bucket"] == "test-target-bucket"
-        assert call_args["collection"] == "test-collection"
-
+        response = s3.list_objects_v2(Bucket="test-target-bucket")
+        assert len(response["Contents"]) == 2
+        assert all(obj["Key"].startswith("test-collection/") for obj in response["Contents"])
         assert result["bucket"] == "veda-data-store"
         assert result["prefix"] == "test-collection/"
 
-def test_transfer_assets_to_production_bucket_transfer_default(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
-    """Test that when transfer is not specified, it defaults to True"""
-
-    with patch("dags.veda_data_pipeline.veda_promotion_pipeline.transfer_data") as mock_transfer, \
-         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
-         patch("boto3.client") as mock_boto3_client:
-        mock_boto3_client.side_effect = lambda service, **kwargs: {
-            'sts': mock_sts_client,
-            's3': mock_s3_client
-        }[service]
-
-        payload = {
-            "bucket": "staging-bucket",
-            "prefix": "staging-prefix/",
-            "filename_regex": r"^.*\.tif$",
-            "transfer": True
-        }
-
-        task_func = transfer_assets_to_production_bucket.function
-        result = task_func(ti=mock_task_instance, payload=payload)
-
-        mock_transfer.assert_called_once()
-        call_args = mock_transfer.call_args[1]["payload"]
-        assert call_args["transfer"] is True
-        assert call_args["origin_bucket"] == "staging-bucket"
-        assert call_args["origin_prefix"] == "staging-prefix/"
-        assert call_args["target_bucket"] == "test-target-bucket"
-        assert call_args["collection"] == "test-collection"
-
-        assert result["bucket"] == "veda-data-store"
-        assert result["prefix"] == "test-collection/"
-
-def test_transfer_assets_to_production_bucket_412_error(mock_task_instance, mock_aws_vars, mock_sts_client, mock_s3_client):
+def test_transfer_assets_to_production_bucket_412_error(mock_task_instance, mock_aws_vars, s3):
     """Test that when a file already exists with the same ETag (412 error), no error is raised"""
     mock_task_instance.dag_run.conf["transfer"] = True
 
-    def head_object_side_effect_412(**kwargs):
-        return {'ETag': '"test-etag"'}
+    s3.copy_object(
+        CopySource={"Bucket": "test-origin-bucket", "Key": "test-prefix/file1.tif"},
+        Bucket="test-target-bucket",
+        Key="test-collection/file1.tif"
+    )
 
-    mock_s3_client.head_object.side_effect = head_object_side_effect_412
-
-    def copy_object_side_effect(**kwargs):
-        error_response = {'Error': {'Code': 'PreconditionFailed', 'Message': 'Precondition Failed'}}
-        raise ClientError(error_response, 'CopyObject')
-
-    mock_s3_client.copy_object.side_effect = copy_object_side_effect
-
-    with patch("dags.veda_data_pipeline.veda_promotion_pipeline.transfer_data") as mock_transfer, \
-         patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)), \
-         patch("boto3.client") as mock_boto3_client:
-        mock_boto3_client.side_effect = lambda service, **kwargs: {
-            'sts': mock_sts_client,
-            's3': mock_s3_client
-        }[service]
-
+    with patch("airflow.models.variable.Variable.get", return_value=json.dumps(mock_aws_vars)):
         payload = {
-            "bucket": "staging-bucket",
-            "prefix": "staging-prefix/",
+            "bucket": "test-origin-bucket",
+            "prefix": "test-prefix/",
             "filename_regex": r"^.*\.tif$",
             "transfer": True
         }
@@ -182,6 +116,7 @@ def test_transfer_assets_to_production_bucket_412_error(mock_task_instance, mock
         task_func = transfer_assets_to_production_bucket.function
         result = task_func(ti=mock_task_instance, payload=payload)
 
-        mock_transfer.assert_called_once()
         assert result["bucket"] == "veda-data-store"
         assert result["prefix"] == "test-collection/"
+        response = s3.list_objects_v2(Bucket="test-target-bucket")
+        assert len(response["Contents"]) == 2

--- a/tests/test_s3_discovery.py
+++ b/tests/test_s3_discovery.py
@@ -5,8 +5,6 @@ import os
 import boto3
 from moto import mock_s3
 
-from unittest.mock import patch
-
 @pytest.fixture(scope='function')
 def aws_credentials():
     """Mocked AWS Credentials, to ensure we're not touching AWS directly"""
@@ -41,10 +39,10 @@ def test_s3_discovery_dry_run(aws_credentials, capsys):
   captured = capsys.readouterr()
   assert "Running discovery in dry run mode" in captured.out
   assert "-DRYRUN- Example item" in captured.out
-  
+
   assert isinstance(res, dict)
   assert res["discovered"] == 2
-  
+
 @mock_s3
 def test_s3_discovery(aws_credentials, capsys):
   s3 = boto3.resource('s3')
@@ -68,6 +66,6 @@ def test_s3_discovery(aws_credentials, capsys):
 
   captured = capsys.readouterr()
   assert "Running discovery in dry run mode" not in captured.out
-  
+
   assert isinstance(res, dict)
   assert res["discovered"] == 2


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses https://github.com/NASA-IMPACT/veda-data-airflow/issues/300

## Changes

* updated `transfer_files_within_s3` to check transfer setting before attempting to transfer files
* set transfer default to true
* when files are up to date and (PreconditionFailed) error is received, continue without erroring. 

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests