### PR TITLE
fix(dataset dag): run submit stack when all build stack tasks are done not all_success

### DIFF
--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import smart_open
 from airflow.models.variable import Variable
 from airflow.decorators import task
+from airflow.utils.trigger_rule import TriggerRule
 from veda_data_pipeline.utils.submit_stac import submission_handler
 
 group_kwgs = {"group_id": "Process", "tooltip": "Process"}
@@ -31,7 +32,7 @@ def remove_thumbnail_asset(ti):
     return payload
 
 # with exponential backoff enabled, retry delay is converted to seconds
-@task(retries=2, retry_delay=60, retry_exponential_backoff=True, max_active_tis_per_dag=5)
+@task(retries=2, retry_delay=60, retry_exponential_backoff=True, max_active_tis_per_dag=5, trigger_rule=TriggerRule.ALL_DONE)
 def submit_to_stac_ingestor_task(built_stac: dict):
     """Submit STAC items to the STAC ingestor API."""
     event = built_stac.copy()

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -115,11 +115,13 @@ def stac_handler(payload_src: dict, bucket_output):
         key=key, payload_success=payload_success, payload_failures=payload_failures
     )
 
-    # Silent dead letters are nice, but we want the Airflow UI to quickly alert us if something went wrong.
+    # Granular error logging should be managed in the task but logging here should help us debug item level failures for now
     if len(payload_failures) != 0:
-        raise ValueError(
-            f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
+        print(
+            ValueError(f"Some items failed to be processed. Failures logged here: {dead_letter_key}")
         )
+        print(f"Failures encounterd for STAC item ids {[failure.get('item_id', None) for failure in payload_failures]}")
+        print(f"Unique errors reported in failures {set([failure.get('error', None) for failure in payload_failures])}")
 
     return {
         "payload": {

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -47,11 +47,11 @@ dag_args = {
 
 with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as dag:
     start = EmptyOperator(task_id="start")
-    end = EmptyOperator(task_id="end")
+    end = EmptyOperator(task_id="end", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
 
     mutated_payloads = start >> collection_task_group() >> remove_thumbnail_asset()
     discovery_items = extract_discovery_items_from_payload(payload=mutated_payloads)
     discover = discover_from_s3_task.partial(payload=mutated_payloads).expand(event=discovery_items)
     get_files = get_files_task(payload=discover)
     build_stac = build_stac_task.expand(payload=get_files)
-    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac, trigger_rule=TriggerRule.ALL_DONE) >> end
+    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> end

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -1,6 +1,7 @@
 import pendulum
 from airflow import DAG
 from airflow.models.param import Param
+from airflow.utils.trigger_rule import TriggerRule
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
 from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
 from veda_data_pipeline.groups.collection_group import collection_task_group
@@ -53,4 +54,4 @@ with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as d
     discover = discover_from_s3_task.partial(payload=mutated_payloads).expand(event=discovery_items)
     get_files = get_files_task(payload=discover)
     build_stac = build_stac_task.expand(payload=get_files)
-    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> end
+    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac, trigger_rule=TriggerRule.ALL_DONE) >> end

--- a/docker_tasks/build_stac/handler.py
+++ b/docker_tasks/build_stac/handler.py
@@ -117,11 +117,13 @@ def stac_handler(payload_event):
         key=key, payload_success=payload_success, payload_failures=payload_failures
     )
 
-    # Silent dead letters are nice, but we want the Airflow UI to quickly alert us if something went wrong.
+    # Granular error logging should be managed in the task but logging here should help us debug item level failures for now
     if len(payload_failures) != 0:
-        raise ValueError(
-            f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
+        print(
+            ValueError(f"Some items failed to be processed. Failures logged here: {dead_letter_key}")
         )
+        print(f"Failures encounterd for STAC item ids {[failure.get('item_id', None) for failure in payload_failures]}")
+        print(f"Unique errors reported in failures {set([failure.get('error', None) for failure in payload_failures])}")
 
     return {
         "payload": {

--- a/docker_tasks/build_stac/handler.py
+++ b/docker_tasks/build_stac/handler.py
@@ -117,17 +117,12 @@ def stac_handler(payload_event):
         key=key, payload_success=payload_success, payload_failures=payload_failures
     )
 
-    # Granular error logging should be managed in the task but logging here should help us debug item level failures for now
+    # Silent dead letters are nice, but we want the Airflow UI to quickly alert us if something went wrong.
     if len(payload_failures) != 0:
-        print(
-            ValueError(f"Some items failed to be processed. Failures logged here: {dead_letter_key}")
+        raise ValueError(
+            f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
         )
-        print(f"Failures encounterd for STAC item ids {[failure.get('item_id', None) for failure in payload_failures]}")
-        print(f"Unique errors reported in failures {set([failure.get('error', None) for failure in payload_failures])}")
-
-    if not len(payload_success):
-        raise ValueError(f"All items failed to be processed. Failures logged here: {dead_letter_key}")
-
+    
     return {
         "payload": {
             "success_event_key": success_key,

--- a/docker_tasks/build_stac/handler.py
+++ b/docker_tasks/build_stac/handler.py
@@ -125,6 +125,9 @@ def stac_handler(payload_event):
         print(f"Failures encounterd for STAC item ids {[failure.get('item_id', None) for failure in payload_failures]}")
         print(f"Unique errors reported in failures {set([failure.get('error', None) for failure in payload_failures])}")
 
+    if not len(payload_success):
+        raise ValueError(f"All items failed to be processed. Failures logged here: {dead_letter_key}")
+
     return {
         "payload": {
             "success_event_key": success_key,


### PR DESCRIPTION
## What
Add `all_done` [trigger rule](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html#trigger-rules) to submit stac step of dataset ingestion pipeline to unblock publishing metadata for valid S3 objects when STAC metadata can be generated at least one discovered S3 object.

1. Run submit stac task when all build stack tasks are done regardless of success
    - The [payload emitted by the build stac task ](https://github.com/NASA-IMPACT/veda-data-airflow/blob/dev/dags/veda_data_pipeline/utils/build_stac/handler.py#L108-L133)separates successful metadata generation from failed metadata generation
    - Submit stac only processes the [successfully generated item metadata from the build stac task](https://github.com/NASA-IMPACT/veda-data-airflow/blob/dev/dags/veda_data_pipeline/groups/processing_tasks.py#L38-L54)

2. Only raise `ValueError` when no metadata was successfully generated (instead of if any item failed in the batch)

## Why
https://github.com/NASA-IMPACT/veda-data-airflow/issues/325

## How to test
When deployed to dev we can try rerunning the dataset ingestion in #325 that is currently failing before any metadata can be published if a single un-publishable item is identified in the discovery step. Our goal is to report what S3 objects caused failures while still publishing metadata for all the other objects discovered.

## NOTE
This work only partially resolves the #325 issue. After confirming that this workflow is unblocked, we will still need to add error reporting and slack notifications 