### PR TITLE
fix: update deprecated objs and fix unit tests

### DIFF
--- a/dags/automated_transformation/automation_dag.py
+++ b/dags/automated_transformation/automation_dag.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from airflow import DAG
 from airflow.decorators import task
 from airflow.models.param import Param
-from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from slack_notifications import slack_fail_alert
 from airflow.models.variable import Variable
 from veda_data_pipeline.utils.xcom_to_s3 import write_xcom_to_s3,read_xcom_from_s3
@@ -28,7 +28,7 @@ dag_run_config = {
         type="string",
         pattern="^[^/].*[^/]$",
     ),
-    # Add a regex pattern after the prefix to filter the raw files 
+    # Add a regex pattern after the prefix to filter the raw files
     "raw_data_filter_regex": Param(".*.nc$", type="string"),
     "dest_data_bucket": "ghgc-data-store-develop",
     "data_prefix": Param("transformed_cogs", type="string", pattern="^[^/].*[^/]$"),
@@ -72,8 +72,8 @@ with DAG(
         on_failure_callback=slack_fail_alert,
         max_active_runs = 1 # Ensure only one DAG at a time to avoid memory issues (code -9)
 ) as dag:
-    start = DummyOperator(task_id="start", dag=dag)
-    end = DummyOperator(task_id="end", dag=dag)
+    start = EmptyOperator(task_id="start", dag=dag)
+    end = EmptyOperator(task_id="end", dag=dag)
 
 
     @task
@@ -192,7 +192,7 @@ with DAG(
             "failures": len(failed_files)
         }
         print(summary)
-    
+
     # @task
     # def report_failure(statuses: list):
     #     all_failures = list()
@@ -203,7 +203,7 @@ with DAG(
     #         raise  Exception(f"Detected {len(all_failures)} errors")
 
 
-    s3_urls = start >> check_function_exists() >> set_max_active_processing()>> discover_files() 
+    s3_urls = start >> check_function_exists() >> set_max_active_processing()>> discover_files()
     report_data = process_files.expand(s3_url=s3_urls)
     statuses = generate_report(reports=report_data)
     #report_failure(statuses=statuses) >> end

--- a/dags/example_dag.py
+++ b/dags/example_dag.py
@@ -3,7 +3,7 @@ import time
 
 import pendulum
 from airflow import DAG
-from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 import sys
 
@@ -41,7 +41,7 @@ def push_to_cmr_task(text):
 with DAG(
     dag_id="example_etl_flow_test",
     start_date=pendulum.today("UTC").add(days=-1),
-    schedule_interval=None,
+    schedule=None,
     tags=["example"],
 ) as dag:
 

--- a/dags/rds_disaster_recovery/rds_s3_export_snapshots.py
+++ b/dags/rds_disaster_recovery/rds_s3_export_snapshots.py
@@ -94,7 +94,7 @@ with DAG(
     dag_id="rds_s3_export_snapshots",
     default_args=default_args,
     tags=["RDS", "Operations", "Disaster Recovery", "Long Term"],
-    schedule_interval=None,
+    schedule=None,
     start_date=days_ago(1),
     max_active_runs=4,  # Only 5 parallel exports are allowed
     catchup=False,
@@ -102,20 +102,20 @@ with DAG(
     render_template_as_native_obj=True,
     doc_md=f"""
         ### RDS to S3 Snapshot Export and S3 Data Crawling
-        This DAG exports an RDS snapshot to S3 and uses AWS Glue to crawl the exported data, 
+        This DAG exports an RDS snapshot to S3 and uses AWS Glue to crawl the exported data,
         making it accessible for querying. The process involves:
-        
+
         ## Workflow
         1. **Export RDS Snapshot**: Initiates an export of the snapshot from RDS to S3 using `RdsStartExportTaskOperator`.
         2. **Monitor Export Completion**: Uses `RdsExportTaskExistenceSensor` to monitor export completion.
         3. **Delete Glue Database**: Deletes any existing Glue database before recreating it.
         4. **Run Glue Crawler**: Initiates a Glue Crawler on the exported S3 data for indexing.
-        
+
         **Parameters**:
         ```json
-        
+
         {default_params}
-        
+
         ```
         """,
 ) as dag:

--- a/dags/veda_data_pipeline/utils/build_stac/__init__.py
+++ b/dags/veda_data_pipeline/utils/build_stac/__init__.py
@@ -1,0 +1,3 @@
+"""
+Build STAC package initialization.
+"""

--- a/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
+++ b/dags/veda_data_pipeline/utils/build_stac/utils/stac.py
@@ -8,8 +8,7 @@ from airflow.models.variable import Variable
 from rio_stac import stac
 from rio_stac.stac import PROJECTION_EXT_VERSION, RASTER_EXT_VERSION
 
-
-from . import events, regex, role
+from veda_data_pipeline.utils.build_stac.utils import events, regex, role
 
 
 def get_sts_session():

--- a/dags/veda_data_pipeline/utils/vector_ingest/handler.py
+++ b/dags/veda_data_pipeline/utils/vector_ingest/handler.py
@@ -9,7 +9,7 @@ import smart_open
 from urllib.parse import urlparse
 import psycopg2
 import geopandas as gpd
-from shapely import wkb
+from shapely.wkb import loads as wkb_loads
 from geoalchemy2 import Geometry
 import sqlalchemy
 from sqlalchemy import create_engine, MetaData, Table, Column, inspect
@@ -166,7 +166,7 @@ def upsert_to_postgis(
     # convert the `t` column to something suitable for sql insertion otherwise we get 'Timestamp(<value>)'
     gdf["t"] = gdf["t"].dt.strftime("%Y-%m-%d %H:%M:%S")
     # convert to WKB
-    gdf["geometry"] = gdf["geometry"].apply(lambda geom: wkb.dumps(geom, hex=True))
+    gdf["geometry"] = gdf["geometry"].apply(lambda geom: wkb_loads(geom, hex=True))
 
     def upsert_batch(batch):
         with engine.connect() as conn:
@@ -249,13 +249,13 @@ def load_to_featuresdb(
         "PostgreSQL",
         connection,
         filename,
-        "-nln", 
+        "-nln",
         collection,
         "-s_srs",
         source_projection,
         "-t_srs",
         target_projection,
-        *extra_flags  
+        *extra_flags
     ]
     out = subprocess.run(
         options,

--- a/dags/veda_data_pipeline/veda_collection_pipeline.py
+++ b/dags/veda_data_pipeline/veda_collection_pipeline.py
@@ -1,22 +1,22 @@
 import pendulum
 from airflow import DAG
-from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
 from veda_data_pipeline.groups.collection_group import collection_task_group
 
 dag_doc_md = """
 ### Collection Creation and Ingestion
-Generates a collection based on the Dataset model and ingests into the catalog 
+Generates a collection based on the Dataset model and ingests into the catalog
 #### Notes
 - This DAG can run with the following configuration <br>
 ```json
 {
-    "collection": "collection-id", 
-    "data_type": "cog", 
+    "collection": "collection-id",
+    "data_type": "cog",
     "description": "collection description",
-    "is_periodic": true, 
+    "is_periodic": true,
     "license": "collection-LICENSE",
-    "time_density": "year", 
+    "time_density": "year",
     "title": "collection-title"
 }
 ```
@@ -24,19 +24,19 @@ Generates a collection based on the Dataset model and ingests into the catalog
 
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
-    "schedule_interval": None,
+    "schedule": None,
     "catchup": False,
     "doc_md": dag_doc_md,
     "tags": ["collection"],
 }
 
 template_dag_run_conf = {
-    "collection": "<collection-id>", 
-    "data_type": "cog", 
-    "description": "<collection-description>", 
-    "is_periodic": "<true|false>", 
-    "license": "<collection-LICENSE>", 
-    "time_density": "<time-density>", 
+    "collection": "<collection-id>",
+    "data_type": "cog",
+    "description": "<collection-description>",
+    "is_periodic": "<true|false>",
+    "license": "<collection-LICENSE>",
+    "time_density": "<time-density>",
     "title": "<collection-title>"
 }
 

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -2,7 +2,7 @@ import pendulum
 from airflow import DAG
 from airflow.models.param import Param
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
-from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
+from airflow.operators.empty import EmptyOperator
 from veda_data_pipeline.groups.collection_group import collection_task_group
 from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset
 
@@ -38,7 +38,7 @@ Generates a collection and triggers the file discovery process
 
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
-    "schedule_interval": None,
+    "schedule": None,
     "catchup": False,
     "doc_md": dag_doc_md,
     "tags": ["collection", "discovery"],

--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -1,6 +1,7 @@
+from queue import Empty
 import pendulum
 from airflow import DAG
-from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.models.param import Param
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
 
@@ -9,7 +10,7 @@ from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_t
 dag_doc_md = """
 ### Discover files from S3
 #### Purpose
-This DAG discovers files from either S3 and/or CMR then runs a DAG id `veda_ingest`. 
+This DAG discovers files from either S3 and/or CMR then runs a DAG id `veda_ingest`.
 The DAG `veda_ingest` will run in parallel processing (2800 files per each DAG)
 #### Notes
 - This DAG can run with the following configuration <br>
@@ -36,7 +37,7 @@ The DAG `veda_ingest` will run in parallel processing (2800 files per each DAG)
             "regex": ".*asset2.*",
         },
     }
-}	
+}
 ```
 - [Supports linking to external content](https://github.com/NASA-IMPACT/veda-data-pipelines)
 """
@@ -74,12 +75,12 @@ def get_discover_dag(id: str, event: dict):
 
     with DAG(
             id,
-            schedule_interval=event.get("schedule"),
+            schedule=event.get("schedule"),
             params=template_dag_run_conf,
             **dag_args
     ) as dag:
-        start = DummyOperator(task_id="Start", dag=dag)
-        end = DummyOperator(
+        start = EmptyOperator(task_id="Start", dag=dag)
+        end = EmptyOperator(
             task_id="End", dag=dag
         )
         # define DAG using taskflow notation

--- a/dags/veda_data_pipeline/veda_promotion_pipeline.py
+++ b/dags/veda_data_pipeline/veda_promotion_pipeline.py
@@ -1,7 +1,7 @@
 import pendulum
 from airflow import DAG
 from airflow.decorators import task
-from airflow.operators.dummy_operator import DummyOperator as EmptyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.models.variable import Variable
 import json
 from veda_data_pipeline.groups.collection_group import collection_task_group
@@ -18,22 +18,22 @@ This will mutate the payload, so that item references will target the new asset 
 - This DAG can run with the following configuration <br>
 ```json
 {
-    "collection": "collection-id", 
-    "data_type": "cog", 
-    "description": "collection description", 
-    "discovery_items": 
+    "collection": "collection-id",
+    "data_type": "cog",
+    "description": "collection description",
+    "discovery_items":
         [
             {
-                "bucket": "veda-data-store-staging", 
-                "datetime_range": "year", 
-                "discovery": "s3", 
-                "filename_regex": "^(.*).tif$", 
+                "bucket": "veda-data-store-staging",
+                "datetime_range": "year",
+                "discovery": "s3",
+                "filename_regex": "^(.*).tif$",
                 "prefix": "example-prefix/"
             }
-        ], 
-    "is_periodic": true, 
-    "license": "collection-LICENSE", 
-    "time_density": "year", 
+        ],
+    "is_periodic": true,
+    "license": "collection-LICENSE",
+    "time_density": "year",
     "title": "collection-title"
 }
 ```
@@ -41,7 +41,7 @@ This will mutate the payload, so that item references will target the new asset 
 
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
-    "schedule_interval": None,
+    "schedule": None,
     "catchup": False,
     "doc_md": dag_doc_md,
     "tags": ["collection", "discovery"],
@@ -65,7 +65,7 @@ template_dag_run_conf = {
     "license": "<collection-LICENSE>",
     "time_density": "<time-density>",
     "title": "<collection-title>",
-    "transfer": "<true|false> # transfer assets to production bucket if true (false by default)", 
+    "transfer": "<true|false> # transfer assets to production bucket if true (false by default)",
 }
 
 @task(max_active_tis_per_dag=3)

--- a/dags/veda_data_pipeline/veda_transfer_pipeline.py
+++ b/dags/veda_data_pipeline/veda_transfer_pipeline.py
@@ -1,6 +1,6 @@
 import pendulum
 from airflow import DAG
-from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.models.param import Param
 from airflow.utils.trigger_rule import TriggerRule
 from veda_data_pipeline.groups.transfer_group import subdag_transfer
@@ -27,7 +27,7 @@ This DAG is used to transfer files that are to permanent locations for indexing 
 
 dag_args = {
     "start_date": pendulum.today("UTC").add(days=-1),
-    "schedule_interval": None,
+    "schedule": None,
     "catchup": False,
     "doc_md": dag_doc_md,
 }
@@ -43,8 +43,8 @@ templat_dag_run_conf = {
 }
 
 with DAG("veda_transfer", params=templat_dag_run_conf, **dag_args) as dag:
-    start = DummyOperator(task_id="Start", dag=dag)
-    end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
+    start = EmptyOperator(task_id="Start", dag=dag)
+    end = EmptyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
 
     transfer_grp = subdag_transfer()
 

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -3,7 +3,7 @@ import pendulum
 from airflow.models.param import Param
 from airflow.decorators import task
 from airflow import DAG
-from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.models.variable import Variable
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
@@ -11,7 +11,7 @@ from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_
 dag_doc_md = """
 ### Build and submit stac
 #### Purpose
-This DAG is supposed to be triggered by `veda_discover`. But you still can trigger this DAG manually or through an API 
+This DAG is supposed to be triggered by `veda_discover`. But you still can trigger this DAG manually or through an API
 
 #### Notes
 - This DAG can run with the following configuration <br>
@@ -34,7 +34,7 @@ This DAG is supposed to be triggered by `veda_discover`. But you still can trigg
     "payload": "s3://data-pipeline-ghgc-dev-mwaa-597746869805/events/test_layer_name2/s3_discover_output_f88257e8-ee50-4a14-ace4-5612ae6ebf38.jsonn"
     "invalidate_cloudfront": true
 
-}	
+}
 ```
 - [Supports linking to external content](https://github.com/NASA-IMPACT/veda-data-pipelines)
 """
@@ -75,11 +75,11 @@ def ingest_vector_task(payload):
 
 @task
 def invalidate_cloudfront(ti):
-    
+
     if not ti.dag_run.conf.get('invalidate_cloudfront'):
         logging.info("Skipping cloudfront invalidation")
         return
-    
+
     import boto3
     try:
         airflow_vars_json = Variable.get("aws_dags_variables", deserialize_json=True)
@@ -110,12 +110,12 @@ def invalidate_cloudfront(ti):
 def get_ingest_vector_dag(id: str, event: dict):
     with DAG(
             id,
-            schedule_interval=event.get("schedule", None),
+            schedule=event.get("schedule", None),
             params=template_dag_run_conf,
             **dag_args
     ) as dag:
-        start = DummyOperator(task_id="Start", dag=dag)
-        end = DummyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
+        start = EmptyOperator(task_id="Start", dag=dag)
+        end = EmptyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
         discover = start >> discover_from_s3_task(event=event)
         get_files = get_files_task(payload=discover)
         ingest_vector_task.expand(payload=get_files) >> invalidate_cloudfront() >> end

--- a/tests/test_dag_integrity.py
+++ b/tests/test_dag_integrity.py
@@ -20,7 +20,7 @@ def dag_bag():
 
     return DagBag(dag_folder="dags/veda_data_pipeline", include_examples=False)
 
-def test_import_dags(dag_bag, ):
+def test_import_dags(dag_bag):
     """
     Test all the libraries can be imported
     """

--- a/tests/test_s3_discovery.py
+++ b/tests/test_s3_discovery.py
@@ -41,10 +41,10 @@ def test_s3_discovery_dry_run(aws_credentials, capsys):
   captured = capsys.readouterr()
   assert "Running discovery in dry run mode" in captured.out
   assert "-DRYRUN- Example item" in captured.out
-  
+
   assert isinstance(res, dict)
   assert res["discovered"] == 2
-  
+
 @mock_s3
 def test_s3_discovery(aws_credentials, capsys):
   s3 = boto3.resource('s3')
@@ -68,6 +68,6 @@ def test_s3_discovery(aws_credentials, capsys):
 
   captured = capsys.readouterr()
   assert "Running discovery in dry run mode" not in captured.out
-  
+
   assert isinstance(res, dict)
   assert res["discovered"] == 2

--- a/tests/test_s3_discovery.py
+++ b/tests/test_s3_discovery.py
@@ -33,6 +33,7 @@ def test_s3_discovery_dry_run(aws_credentials, capsys):
   fake_event = {
     "dry_run": "dry run",
     "bucket": "test",
+    "prefix": "",
     "filename_regex": r"[\s\S]*"
   }
 
@@ -43,7 +44,7 @@ def test_s3_discovery_dry_run(aws_credentials, capsys):
   assert "-DRYRUN- Example item" in captured.out
 
   assert isinstance(res, dict)
-  assert res["discovered"] == 2
+  assert res["discovered"] == [2]
 
 @mock_s3
 def test_s3_discovery(aws_credentials, capsys):
@@ -61,6 +62,7 @@ def test_s3_discovery(aws_credentials, capsys):
   client.put_object(Bucket="test", Key="file2.txt", Body="stuff")
   fake_event = {
     "bucket": "test",
+    "prefix": "",
     "filename_regex": r"^.*\.(cog|tif)$"
   }
 
@@ -70,4 +72,4 @@ def test_s3_discovery(aws_credentials, capsys):
   assert "Running discovery in dry run mode" not in captured.out
 
   assert isinstance(res, dict)
-  assert res["discovered"] == 2
+  assert res["discovered"] == [2]

--- a/tests/test_submit_stac.py
+++ b/tests/test_submit_stac.py
@@ -29,7 +29,7 @@ def create_secret(aws):
 @requests_mock.Mocker(kw="mock")
 def test_submission_handler_dry_run(create_secret, capsys, **kwargs):
   token_endpoint = kwargs["mock"].post("http://test.com/oauth2/token", json={"token_type": "bearer", "access_token": "token"})
-  ingestions_endpoint = kwargs["mock"].post("http://www.test.com/ingestions", json={"token_type": "bearer", "access_token": "token"})
+  ingestions_endpoint = kwargs["mock"].post("http://www.test.com/ingestions", json={"id": "123", "status": "success", "message": "STAC item ingested successfully"})
   fake_event = {
     "dry_run": "dry run",
     "stac_file_url": "http://www.test.com",
@@ -45,9 +45,9 @@ def test_submission_handler_dry_run(create_secret, capsys, **kwargs):
   assert ingestions_endpoint.call_count == 0
 
 @requests_mock.Mocker(kw="mock")
-def test_submission_handler( create_secret, capsys, **kwargs):
+def test_submission_handler(create_secret, capsys, **kwargs):
   token_endpoint = kwargs["mock"].post("http://test.com/oauth2/token", json={"token_type": "bearer", "access_token": "token"})
-  ingestions_endpoint = kwargs["mock"].post("http://www.test.com/ingestions", json={"token_type": "bearer", "access_token": "token"})
+  ingestions_endpoint = kwargs["mock"].post("http://www.test.com/ingestions", json={"id": "123", "status": "success", "message": "STAC item ingested successfully"})
   fake_event = {
     "stac_file_url": "http://www.test.com",
     "stac_item": 123
@@ -55,7 +55,7 @@ def test_submission_handler( create_secret, capsys, **kwargs):
 
   res = submit_stac.submission_handler(fake_event)
 
-  assert res == None
+  assert res == {"id": "123", "status": "success", "message": "STAC item ingested successfully"}
   captured = capsys.readouterr()
   assert "Dry run, not inserting" not in captured.out
   assert token_endpoint.call_count == 1


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses https://github.com/NASA-IMPACT/veda-data-airflow/issues/344

## Changes

* [schedule_interval is now schedule](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#deprecation-of-schedule-interval-and-timetable-arguments-25410)
* [DummyOperator is now EmptyOperator](https://airflow.apache.org/docs/apache-airflow/2.3.4/_api/airflow/operators/dummy/index.html)

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests