### PR TITLE
Revise constraints to keep xmlsec from updating

### DIFF
--- a/sm2a/airflow_services/Dockerfile
+++ b/sm2a/airflow_services/Dockerfile
@@ -20,7 +20,7 @@ USER airflow
 
 RUN pip install --upgrade pip \
   && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
-  && pip install --no-cache-dir -r requirements-in.txt -c apache-airflow==${AIRFLOW_VERSION}
+  && pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
 
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"
 COPY --chown=airflow:airflow plugins "${AIRFLOW_HOME}/plugins"

--- a/sm2a/airflow_worker/Dockerfile
+++ b/sm2a/airflow_worker/Dockerfile
@@ -41,9 +41,9 @@ COPY --chown=airflow:airflow airflow_worker/requirements.txt "${AIRFLOW_HOME}/re
 COPY --chown=airflow:airflow airflow_worker/requirements-in.txt "${AIRFLOW_HOME}/requirements-in.txt"
 
 RUN pip install --upgrade pip \
-    && pip install "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}"\
+    && pip install "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}" -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
     && pip install --no-cache-dir -r requirements.txt -c "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt"\
-    && pip install --no-cache-dir -r requirements-in.txt -c apache-airflow==${AIRFLOW_VERSION}
+    && pip install --no-cache-dir -r requirements-in.txt apache-airflow==${AIRFLOW_VERSION}
 
 COPY --chown=airflow:airflow dags "${AIRFLOW_HOME}/dags"
 COPY --chown=airflow:airflow plugins "${AIRFLOW_HOME}/plugins"


### PR DESCRIPTION
Small fix - just making sure Airflow dependencies are pinned properly (this began to raise errors after `xmlsec` pushed a broken update)