### PR TITLE
Use veda keycloak in submit stac util

### DIFF
--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -9,7 +9,6 @@ from veda_data_pipeline.utils.submit_stac import submission_handler
 
 group_kwgs = {"group_id": "Process", "tooltip": "Process"}
 
-
 def log_task(text: str):
     logging.info(text)
 
@@ -39,7 +38,7 @@ def submit_to_stac_ingestor_task(built_stac: dict):
 
     airflow_vars = Variable.get("aws_dags_variables")
     airflow_vars_json = json.loads(airflow_vars)
-    cognito_app_secret = airflow_vars_json.get("COGNITO_APP_SECRET")
+    app_secret = airflow_vars_json.get("INGEST_API_KEYCLOAK_APP_SECRET")
     stac_ingestor_api_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
     try:
         success_file = event["payload"]["success_event_key"]
@@ -53,7 +52,7 @@ def submit_to_stac_ingestor_task(built_stac: dict):
         submission_handler(
             event=item,
             endpoint="/ingestions",
-            cognito_app_secret=cognito_app_secret,
+            app_secret=app_secret,
             stac_ingestor_api_url=stac_ingestor_api_url,
         )
     return event
@@ -63,13 +62,13 @@ def submit_to_stac_ingestor_task_direct(stac_items: dict):
     # to submit items without a success file
     airflow_vars = Variable.get("aws_dags_variables")
     airflow_vars_json = json.loads(airflow_vars)
-    cognito_app_secret = airflow_vars_json.get("COGNITO_APP_SECRET")
+    app_secret = airflow_vars_json.get("INGEST_API_KEYCLOAK_APP_SECRET")
     stac_ingestor_api_url = airflow_vars_json.get("STAC_INGESTOR_API_URL")
 
     submission_handler(
         event=stac_items,
         endpoint="/ingestions",
-        cognito_app_secret=cognito_app_secret,
+        app_secret=app_secret,
         stac_ingestor_api_url=stac_ingestor_api_url,
     )
     return

--- a/dags/veda_data_pipeline/utils/submit_stac.py
+++ b/dags/veda_data_pipeline/utils/submit_stac.py
@@ -26,18 +26,19 @@ class StacItemInput(InputBase):
     stac_item: Dict[str, Any]
 
 
-class AppConfig(TypedDict):
-    cognito_domain: str
-    client_id: str
-    client_secret: str
-    scope: str
+class Secret(TypedDict):
+    userinfo_url: str
+    id: str
+    secret: str
+    auth_url: str
+    token_url: str
 
 
 class Creds(TypedDict):
     access_token: str
     expires_in: int
     token_type: str
-
+    scope: str
 
 @dataclass
 class IngestionApi:
@@ -46,30 +47,31 @@ class IngestionApi:
 
     @classmethod
     def from_veda_auth_secret(cls, *, secret_id: str, base_url: str) -> "IngestionApi":
-        cognito_details = cls._get_cognito_service_details(secret_id)
-        credentials = cls._get_app_credentials(**cognito_details)
+        secret_details = cls._get_auth_service_details(secret_id)
+        credentials = cls._get_app_credentials(**secret_details)
         return cls(token=credentials["access_token"], base_url=base_url)
 
     @staticmethod
-    def _get_cognito_service_details(secret_id: str) -> AppConfig:
+    def _get_auth_service_details(secret_id: str) -> Secret:
         client = boto3.client("secretsmanager")
         response = client.get_secret_value(SecretId=secret_id)
         return json.loads(response["SecretString"])
 
     @staticmethod
     def _get_app_credentials(
-        cognito_domain: str, client_id: str, client_secret: str, scope: str, **kwargs
+        userinfo_url: str, id: str, secret: str, auth_url: str, token_url: str, **kwargs
     ) -> Creds:
         response = requests.post(
-            f"{cognito_domain}/oauth2/token",
+            token_url,
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json"
             },
-            auth=(client_id, client_secret),
             data={
+                "client_id": id,
+                "client_secret": secret,
                 "grant_type": "client_credentials",
-                # A space-separated list of scopes to request for the generated access token.
-                "scope": scope,
+                "scope": "stac:item:create stac:item:update stac:collection:create stac:collection:update"
             },
         )
         try:
@@ -100,7 +102,7 @@ class IngestionApi:
 def submission_handler(
     event: Union[S3LinkInput, StacItemInput, Dict[str, Any]],
     endpoint: str = "/ingestions",
-    cognito_app_secret=None,
+    app_secret=None,
     stac_ingestor_api_url=None,
     context=None,
 ) -> None | dict:
@@ -114,11 +116,8 @@ def submission_handler(
         print(json.dumps(stac_item, indent=2))
         return
 
-    cognito_app_secret = cognito_app_secret or os.getenv("COGNITO_APP_SECRET")
-    stac_ingestor_api_url = stac_ingestor_api_url or os.getenv("STAC_INGESTOR_API_URL")
-
     ingestor = IngestionApi.from_veda_auth_secret(
-        secret_id=cognito_app_secret,
+        secret_id=app_secret,
         base_url=stac_ingestor_api_url,
     )
     return ingestor.submit(event=stac_item, endpoint=endpoint)

--- a/sm2a/infrastructure/main.tf
+++ b/sm2a/infrastructure/main.tf
@@ -103,8 +103,9 @@ module "sma-base" {
     ASSUME_ROLE_READ_ARN  = var.assume_role_read_arn,
     ASSUME_ROLE_WRITE_ARN = var.assume_role_write_arn,
     SM2A_BASE_URL         = module.sma-base.airflow_url,
-    CLOUDFRONT_TO_INVALIDATE = var.cloudfront_to_invalidate
-    CLOUDFRONT_PATH_TO_INVALIDATE = var.cloudfront_path_to_invalidate
+    CLOUDFRONT_TO_INVALIDATE = var.cloudfront_to_invalidate,
+    CLOUDFRONT_PATH_TO_INVALIDATE = var.cloudfront_path_to_invalidate,
+    INGEST_API_KEYCLOAK_APP_SECRET=var.ingest_api_keycloak_client_secret
   }, var.snapshot_bucket_name != "" ? module.rds_backups[0].rds_backup_environment : {}
   )
 }

--- a/sm2a/infrastructure/variables.tf
+++ b/sm2a/infrastructure/variables.tf
@@ -243,3 +243,7 @@ variable "cloudfront_path_to_invalidate" {
 variable "lambda_dag_trigger_function_name" {
   default = "trigger-sm2a-dag"
 }
+
+variable ingest_api_keycloak_client_secret {
+ type = string
+}


### PR DESCRIPTION
- refactors `submit_stac` util to use veda-keycloak endpoints, secret id/key via app secret
- requires new ENV `TF_VAR_ingest_api_keycloak_client_secret=veda-keycloak-dev-client-airflow-ingest-api-etl`
- this PR is dependent on https://github.com/NASA-IMPACT/veda-backend/pull/478