### PR TITLE
Bring back scheduled DAGs

### DIFF
--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -10,7 +10,7 @@ from veda_data_pipeline.veda_discover_pipeline import get_discover_dag
 from veda_data_pipeline.veda_vector_pipeline import get_ingest_vector_dag
 
 from airflow.models import DagBag
-existing_dag_ids = set(DagBag().dags.keys())
+existing_dag_ids = DagBag().dag_ids
 
 def filter_configs_by_dag(
         collection_configs: List[Dict[str, int]],

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -9,9 +9,6 @@ from typing import Dict, List, Optional
 from veda_data_pipeline.veda_discover_pipeline import get_discover_dag
 from veda_data_pipeline.veda_vector_pipeline import get_ingest_vector_dag
 
-from airflow.models import DagBag
-existing_dag_ids = DagBag().dag_ids
-
 def filter_configs_by_dag(
         collection_configs: List[Dict[str, int]],
         dag: Optional[str] = "veda_discover"
@@ -76,9 +73,6 @@ def generate_dags():
             id = f"discover-{file_name}"
             if idx > 0:
                 id = f"{id}-{idx}"
-            if id in existing_dag_ids:
-                print(f"Skipping duplicate DAG ID: {id}")
-                continue
             get_discover_dag(
                 id=id, event=discovery_config
             )
@@ -90,9 +84,6 @@ def generate_dags():
             id = f"vector-{file_name}"
             if idx > 0:
                 id = f"{id}-{idx}"
-            if id in existing_dag_ids:
-                print(f"Skipping duplicate DAG ID: {id}")
-                continue
             get_ingest_vector_dag(
                 id=id, event=vector_config
             )

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -88,5 +88,6 @@ def generate_dags():
                 id=id, event=vector_config
             )
 
-
 generate_dags()
+get_ingest_vector_dag(id="veda_ingest_vector", event={})
+get_discover_dag(id="veda_discover", event={})

--- a/dags/veda_data_pipeline/veda_discover_pipeline.py
+++ b/dags/veda_data_pipeline/veda_discover_pipeline.py
@@ -98,4 +98,4 @@ def get_discover_dag(id: str, event: dict):
 
 # Sending empty event because we rely on task instance (ti) for manula runs
 # and payload for scheduled runs
-get_discover_dag(id="veda_discover", event={})
+# get_discover_dag(id="veda_discover", event={})

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -125,4 +125,4 @@ def get_ingest_vector_dag(id: str, event: dict):
 
 # Sending empty event because we rely on task instance (ti) for manual runs
 # and payload for scheduled runs
-get_ingest_vector_dag(id="veda_ingest_vector", event={})
+# get_ingest_vector_dag(id="veda_ingest_vector", event={})


### PR DESCRIPTION
**Summary:** 

Fixes #372 
Currently live on https://sm2a.sit.openveda.cloud

Accessing the DagBag seems to short-circuit generating new DAGs with `generate_dags`. 

Airflow's `dag_bag.py` only performs a top-level scan of the files it parses. Because `generate_dags.py` uses functions from `veda_discover_pipeline.py`, as far as the `DagBag` is concerned, `veda_discover_pipeline` generates the same DAGs as `generate_dags.py` (this was hard to debug, but this is the best explanation I could come up with)

Duplicate DAGs are already blocked by Airflow - these changes are to satisfy the integrity constraints in our unit tests. In the future, we could consider removing these unit tests and adding integration tests against the `docker compose` stack, in order to validate DAG integrity after DAGs have been fully processed.

## PR Checklist

- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests