### PR TITLE
Access ingest api secret in different aws account

### DIFF
--- a/sm2a/infrastructure/iam.tf
+++ b/sm2a/infrastructure/iam.tf
@@ -1,0 +1,76 @@
+locals {
+
+  base_policies = [
+    {
+      Effect = "Allow"
+      Action = [
+        "sts:AssumeRole",
+        "iam:PassRole",
+        "logs:GetLogEvents"
+      ]
+      Resource = ["*"]
+    },
+    {
+      Effect = "Allow"
+      Action = ["glue:DeleteDatabase"]
+      Resource = [
+        "arn:aws:glue:us-west-2:*:catalog",
+        "arn:aws:glue:us-west-2:*:database/*",
+        "arn:aws:glue:us-west-2:*:table/*",
+        "arn:aws:glue:us-west-2:*:userDefinedFunction/*"
+      ]
+    },
+  ]
+
+  # Disaster Recovery
+  disaster_recovery_policy = [
+    {
+      Effect = "Allow"
+      Action = [
+        "rds:Describe*", 
+        "rds:Start*", "kms:*", 
+        "glue:Get*", 
+        "glue:CreateCrawler", 
+        "glue:StartCrawler", 
+        "glue:UpdateCrawler"
+      ]
+      Resource = ["*"]
+    }
+  ]
+
+  #Cloudfront Invalidation
+  cloudfront_invalidation_policy = [
+    {
+      Effect = "Allow"
+      Action = ["cloudfront:CreateInvalidation"]
+      Resource = ["arn:aws:cloudfront::*:distribution/*"]
+    }
+  ]
+
+  # Conditional Secrets Manager arn for ingest api keycloak client secret in different aws account
+  secrets_manager_policy = var.ingest_api_keycloak_client_secret_arn != null ? [
+    {
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = [var.ingest_api_keycloak_client_secret_arn]
+    }
+  ] : []
+
+  # Conditional KMS policy statement
+  kms_policy = var.kms_key_arn != null ? [
+    {
+      Effect   = "Allow"
+      Action   = ["kms:Decrypt"]
+      Resource = [var.kms_key_arn]
+    }
+  ] : []
+
+  # Final list of all worker policy statements
+  custom_worker_policy_statement = concat(
+    local.base_policies,
+    local.disaster_recovery_policy,
+    local.cloudfront_invalidation_policy,
+    local.secrets_manager_policy,
+    local.kms_policy
+  )
+} 

--- a/sm2a/infrastructure/main.tf
+++ b/sm2a/infrastructure/main.tf
@@ -10,6 +10,7 @@ terraform {
 provider "aws" {
   region = var.aws_region
 }
+
 resource "random_password" "password" {
   length           = 8
   special          = true
@@ -23,7 +24,6 @@ module "rds_backups" {
   permission_boundaries_arn = var.permission_boundaries_arn
   snapshot_bucket_name = var.snapshot_bucket_name
 }
-
 
 module "sma-base" {
   source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.7/self-managed-apache-airflow.zip"
@@ -40,7 +40,7 @@ module "sma-base" {
   airflow_admin_username         = "admin"
   rds_publicly_accessible        = var.rds_publicly_accessible
   permission_boundaries_arn      = var.permission_boundaries_arn
-  custom_worker_policy_statement = var.custom_worker_policy_statement
+  custom_worker_policy_statement = local.custom_worker_policy_statement
   worker_cpu                     = tonumber(var.workers_cpu)
   worker_memory                  = tonumber(var.workers_memory)
   number_of_schedulers           = var.number_of_schedulers

--- a/sm2a/infrastructure/variables.tf
+++ b/sm2a/infrastructure/variables.tf
@@ -79,63 +79,6 @@ variable "gh_team_name" {
 
 }
 
-variable "custom_worker_policy_statement" {
-  type = list(object({
-    Effect   = string
-    Action   = list(string)
-    Resource = list(string)
-  }))
-  default = [
-    {
-      Effect = "Allow"
-      Action = [
-        "sts:AssumeRole",
-        "iam:PassRole",
-        "logs:GetLogEvents"
-      ]
-      "Resource" : [
-        "*"
-      ]
-
-    },
-        {
-      Sid    = "VEDA-RDS-Disaster-Recovery"
-      Effect = "Allow"
-      Action = [
-        "rds:Describe*",
-        "rds:Start*",
-        "kms:*",
-        "glue:Get*",
-        "glue:CreateCrawler",
-        "glue:StartCrawler",
-        "glue:UpdateCrawler"
-      ]
-      Resource = [
-        "*"
-      ]
-    },
-    {
-      "Effect" : "Allow",
-      "Action" : [
-        "glue:DeleteDatabase"
-      ],
-      "Resource" : [
-        "arn:aws:glue:us-west-2:*:catalog",
-        "arn:aws:glue:us-west-2:*:database/*",
-        "arn:aws:glue:us-west-2:*:table/*",
-        "arn:aws:glue:us-west-2:*:userDefinedFunction/*"
-      ]
-    },
-    {
-            "Effect": "Allow",
-            "Action": ["cloudfront:CreateInvalidation"],
-            "Resource": ["arn:aws:cloudfront::*:distribution/*"]
-    }
-
-  ]
-
-}
-
 variable "project_name" {
   type    = string
   default = "SM2A"
@@ -246,4 +189,16 @@ variable "lambda_dag_trigger_function_name" {
 
 variable ingest_api_keycloak_client_secret {
  type = string
+}
+
+variable "ingest_api_keycloak_client_secret_arn" {
+  type        = string
+  description = "Secrets Manager arn for ingest api keycloak client secret in different aws account"
+  default     = null
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key in different aws account"
+  default     = null
 }


### PR DESCRIPTION
## Description

We have a case where we need to access the MCP keycloak ingest api etl secret from SMCE. This PR implements step 3 from this guide: https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_examples_cross.html

The PR also refactors how the custom worker iam policies are recorded. Previously they were listed in variables.tf which made it difficult to handle conditionals. They are now included in `iam.tf` as locals.