### PR TITLE
feat: improve failure reporting in build stac task

### DIFF
--- a/airflow_services/Dockerfile
+++ b/airflow_services/Dockerfile
@@ -31,6 +31,4 @@ COPY --chown=airflow:airflow airflow_services/webserver_config.py "${AIRFLOW_HOM
 RUN cp ${AIRFLOW_HOME}/configuration/airflow.cfg* ${AIRFLOW_HOME}/.
 
 #ENV
-# ENV PYTHONPATH /opt/airflow
-ENV PATH /home/airflow/miniconda3/envs/py11/bin:$PATH
-ENV PYTHONPATH /opt/airflow:/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages
+ENV PYTHONPATH /opt/airflow

--- a/airflow_services/Dockerfile
+++ b/airflow_services/Dockerfile
@@ -31,4 +31,6 @@ COPY --chown=airflow:airflow airflow_services/webserver_config.py "${AIRFLOW_HOM
 RUN cp ${AIRFLOW_HOME}/configuration/airflow.cfg* ${AIRFLOW_HOME}/.
 
 #ENV
-ENV PYTHONPATH /opt/airflow
+# ENV PYTHONPATH /opt/airflow
+ENV PATH /home/airflow/miniconda3/envs/py11/bin:$PATH
+ENV PYTHONPATH /opt/airflow:/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -75,8 +75,8 @@ def submit_to_stac_ingestor_task_direct(stac_items: dict):
 
 
 @task(max_active_tis_per_dag=5)
-def build_stac_task(payload):
+def build_stac_task(payload, ti=None):
     from veda_data_pipeline.utils.build_stac.handler import stac_handler
     airflow_vars_json = Variable.get("aws_dags_variables", deserialize_json=True)
     event_bucket = airflow_vars_json.get("EVENT_BUCKET")
-    return stac_handler(payload_src=payload, bucket_output=event_bucket)
+    return stac_handler(payload_src=payload, bucket_output=event_bucket, ti=ti)

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -169,7 +169,7 @@ def stac_handler(payload_src: dict, bucket_output):
             logging.warning(
                 f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
             )
-            raise AirflowException(f"Build STAC completed with {len(payload_failures)} failures. See logs for details.")
+            raise AirflowException(f"Build STAC completed with {len(payload_failures)} failures. See logs for details {dead_letter_key}")
 
         return result
 

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -128,13 +128,7 @@ def stac_handler(payload_src: dict, bucket_output, ti=None):
             key=key, payload_success=payload_success, payload_failures=payload_failures
         )
 
-        if ti:
-            duration = ti.duration.total_seconds()
-        else:
-            duration = 0
-
         total_processed = len(payload_success) + len(payload_failures)
-        items_per_second = total_processed / duration if duration > 0 else 0
 
         logging.info("\n=== Run Summary ===")
         logging.info(f"Collection: {collection}")
@@ -142,8 +136,6 @@ def stac_handler(payload_src: dict, bucket_output, ti=None):
         logging.info(f"Successes: {len(payload_success)}")
         logging.info(f"Failures: {len(payload_failures)}")
         logging.info(f"Success Rate: {(len(payload_success) / total_processed) * 100:.2f}%" if total_processed > 0 else "0%")
-        logging.info(f"Duration: {duration:.2f} seconds")
-        logging.info(f"Processing Rate: {items_per_second:.2f} items/second")
 
         if payload_failures:
             logging.warning("\n=== Error Breakdown ===")

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -168,9 +168,8 @@ def stac_handler(payload_src: dict, bucket_output, ti=None):
 
         if len(payload_failures) != 0:
             logging.warning(
-                f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
+                f"Build STAC completed with {len(payload_failures)} failures. See logs for details {dead_letter_key}"
             )
-            raise AirflowException(f"Build STAC completed with {len(payload_failures)} failures. See logs for details {dead_letter_key}")
 
         return result
 

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -1,10 +1,13 @@
+import logging
 import json
+from datetime import datetime
 from typing import Any, Dict, TypedDict, Union
 from uuid import uuid4
 import smart_open
 from veda_data_pipeline.utils.build_stac.utils import events
 from veda_data_pipeline.utils.build_stac.utils import stac
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from airflow.exceptions import AirflowException
 
 
 
@@ -88,46 +91,88 @@ def write_outputs_to_s3(key, payload_success, payload_failures):
     return [success_key, dead_letter_key]
 
 
+
 def stac_handler(payload_src: dict, bucket_output):
+    start_time = datetime.now()
     payload_event = payload_src.copy()
     s3_event = payload_event.pop("payload")
     collection = payload_event.get("collection", "not_provided")
     key = f"s3://{bucket_output}/events/{collection}"
     payload_success = []
     payload_failures = []
-    with smart_open.open(s3_event, "r") as _file:
-        s3_event_read = _file.read()
-    event_received = json.loads(s3_event_read)
-    objects = event_received["objects"]
-    use_multithreading = payload_event.get("use_multithreading", True)
-    payloads = (
-        using_pool(objects, workers_count=4)
-        if use_multithreading
-        else sequential_processing(objects)
-    )
-    for payload in payloads:
-        stac_item = payload["stac_item"]
-        if "error" in stac_item:
-            payload_failures.append(stac_item)
-        else:
-            payload_success.append(stac_item)
-    success_key, dead_letter_key = write_outputs_to_s3(
-        key=key, payload_success=payload_success, payload_failures=payload_failures
-    )
 
-    # Silent dead letters are nice, but we want the Airflow UI to quickly alert us if something went wrong.
-    if len(payload_failures) != 0:
-        raise ValueError(
-            f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
+    try:
+        logging.info(f"=== Starting build_stac for collection {collection} ===")
+        with smart_open.open(s3_event, "r") as _file:
+            s3_event_read = _file.read()
+        event_received = json.loads(s3_event_read)
+        objects = event_received["objects"]
+
+        logging.info(f"Total items to process is: {len(objects)}")
+
+        use_multithreading = payload_event.get("use_multithreading", True)
+        payloads = (
+            using_pool(objects, workers_count=4)
+            if use_multithreading
+            else sequential_processing(objects)
+        )
+        for index, payload in enumerate(payloads, 1):
+            stac_item = payload["stac_item"]
+            if "error" in stac_item:
+                payload_failures.append(stac_item)
+            else:
+                payload_success.append(stac_item)
+
+            if index % 100 == 0:
+                logging.info(f"Processed {index} items of {len(objects)}")
+
+        success_key, dead_letter_key = write_outputs_to_s3(
+            key=key, payload_success=payload_success, payload_failures=payload_failures
         )
 
-    return {
-        "payload": {
-            "success_event_key": success_key,
-            "failed_event_key": dead_letter_key,
-            "status": {
-                "successes": len(payload_success),
-                "failures": len(payload_failures),
-            },
+        end_time = datetime.now()
+        duration = (end_time - start_time).total_seconds()
+        total_processed = len(payload_success) + len(payload_failures)
+        items_per_second = total_processed / duration if duration > 0 else 0
+
+        logging.info("\n=== Run Summary ===")
+        logging.info(f"Collection: {collection}")
+        logging.info(f"Total Processed: {total_processed}")
+        logging.info(f"Successes: {len(payload_success)}")
+        logging.info(f"Failures: {len(payload_failures)}")
+        logging.info(f"Success Rate: {(len(payload_success) / total_processed) * 100:.2f}%" if total_processed > 0 else "0%")
+        logging.info(f"Duration: {duration:.2f} seconds")
+        logging.info(f"Processing Rate: {items_per_second:.2f} items/second")
+
+        if payload_failures:
+            logging.warning("\n=== Error Breakdown ===")
+            error_breakdown = {}
+            for failure in payload_failures:
+                error_msg = failure.get('error', 'Unknown error')
+                error_breakdown[error_msg] = error_breakdown.get(error_msg, 0) + 1
+
+            for error, count in error_breakdown.items():
+                logging.warning(f"  - {error}: {count} occurrences")
+
+        result = {
+            "payload": {
+                "success_event_key": success_key,
+                "failed_event_key": dead_letter_key,
+                "status": {
+                    "successes": len(payload_success),
+                    "failures": len(payload_failures),
+                }
+            }
         }
-    }
+
+        if len(payload_failures) != 0:
+            logging.warning(
+                f"Some items failed to be processed. Failures logged here: {dead_letter_key}"
+            )
+            raise AirflowException(f"Build STAC completed with {len(payload_failures)} failures. See logs for details.")
+
+        return result
+
+    except Exception as e:
+        logging.error(f"Unexpected error in build stac process: {str(e)}")
+        raise

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -1,6 +1,5 @@
 import logging
 import json
-from datetime import datetime
 from typing import Any, Dict, TypedDict, Union
 from uuid import uuid4
 import smart_open
@@ -92,8 +91,7 @@ def write_outputs_to_s3(key, payload_success, payload_failures):
 
 
 
-def stac_handler(payload_src: dict, bucket_output):
-    start_time = datetime.now()
+def stac_handler(payload_src: dict, bucket_output, ti=None):
     payload_event = payload_src.copy()
     s3_event = payload_event.pop("payload")
     collection = payload_event.get("collection", "not_provided")
@@ -130,8 +128,11 @@ def stac_handler(payload_src: dict, bucket_output):
             key=key, payload_success=payload_success, payload_failures=payload_failures
         )
 
-        end_time = datetime.now()
-        duration = (end_time - start_time).total_seconds()
+        if ti:
+            duration = ti.duration.total_seconds()
+        else:
+            duration = 0
+
         total_processed = len(payload_success) + len(payload_failures)
         items_per_second = total_processed / duration if duration > 0 else 0
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,7 +26,7 @@ module "rds_backups" {
 
 
 module "sma-base" {
-  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.7/self-managed-apache-airflow.zip"
+  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.8/self-managed-apache-airflow.zip"
   project                        = var.project_name
   airflow_db                     = var.airflow_db
   fernet_key                     = var.fernet_key

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,7 +26,7 @@ module "rds_backups" {
 
 
 module "sma-base" {
-  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.8/self-managed-apache-airflow.zip"
+  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.9/self-managed-apache-airflow.zip"
   project                        = var.project_name
   airflow_db                     = var.airflow_db
   fernet_key                     = var.fernet_key

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,7 +26,7 @@ module "rds_backups" {
 
 
 module "sma-base" {
-  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.9/self-managed-apache-airflow.zip"
+  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.10/self-managed-apache-airflow.zip"
   project                        = var.project_name
   airflow_db                     = var.airflow_db
   fernet_key                     = var.fernet_key


### PR DESCRIPTION
**Summary:**

Addresses https://github.com/NASA-IMPACT/veda-data-airflow/issues/382

## Changes

Failed run summary can be viewed here: https://sm2a.sit.openveda.cloud/dags/veda_dataset_pipeline/grid?run_id=manual__2025-06-17T16%3A04%3A38%2B00%3A00&execution_date=2025-06-17+16%3A04%3A38%2B00%3A00&tab=mapped_tasks&dag_run_id=manual__2025-06-17T16%3A04%3A38%2B00%3A00&task_id=build_stac_task&map_index=0
```
[2025-06-17, 16:11:33 UTC] {handler.py:105} INFO - === Starting build_stac for collection ida-ndwi-difference-test-reporting-fail ===
[2025-06-17, 16:11:33 UTC] {handler.py:111} INFO - Total items to process is: 1
.
.
.
=== Run Summary ===
[2025-06-17, 16:11:33 UTC] {handler.py:139} INFO - Collection: ida-ndwi-difference-test-reporting-fail
[2025-06-17, 16:11:33 UTC] {handler.py:140} INFO - Total Processed: 1
[2025-06-17, 16:11:33 UTC] {handler.py:141} INFO - Successes: 0
[2025-06-17, 16:11:33 UTC] {handler.py:142} INFO - Failures: 1
[2025-06-17, 16:11:33 UTC] {handler.py:143} INFO - Success Rate: 0.00%
[2025-06-17, 16:11:33 UTC] {handler.py:144} INFO - Duration: 0.61 seconds
[2025-06-17, 16:11:33 UTC] {handler.py:145} INFO - Processing Rate: 1.63 items/second
[2025-06-17, 16:11:33 UTC] {handler.py:148} WARNING - 
=== Error Breakdown ===
[2025-06-17, 16:11:33 UTC] {handler.py:155} WARNING -   - No dates found in event config or by regex: 1 occurrences
[2025-06-17, 16:11:33 UTC] {handler.py:169} WARNING - Some items failed to be processed. Failures logged here: s3://veda-tf-state-shared/events/ida-ndwi-difference-test-reporting-fail/dead_letter_events/build_stac_failed_ada9e450-528a-4aba-bea2-55ff65be137b.json
[2025-06-17, 16:11:33 UTC] {handler.py:177} ERROR - Unexpected error in build stac process: Build STAC completed with 1 failures. See logs for details.
[2025-06-17, 16:11:33 UTC] {taskinstance.py:2731} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 444, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 414, in _execute_callable
    return execute_callable(context=context, **execute_callable_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/decorators/base.py", line 241, in execute
    return_value = super().execute(context)
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/operators/python.py", line 200, in execute
    return_value = self.execute_callable()
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/miniconda3/envs/py11/lib/python3.11/site-packages/airflow/operators/python.py", line 217, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/dags/veda_data_pipeline/groups/processing_tasks.py", line 82, in build_stac_task
    return stac_handler(payload_src=payload, bucket_output=event_bucket)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/dags/veda_data_pipeline/utils/build_stac/handler.py", line 172, in stac_handler
    raise AirflowException(f"Build STAC completed with {len(payload_failures)} failures. See logs for details.")
airflow.exceptions.AirflowException: Build STAC completed with 1 failures. See logs for details.
[2025-06-17, 16:11:33 UTC] {taskinstance.py:1149} INFO - Marking task as FAILED. dag_id=veda_dataset_pipeline, task_id=build_stac_task, map_index=0, execution_date=20250617T160438, start_date=20250617T161132, end_date=20250617T161133
[2025-06-17, 16:11:33 UTC] {standard_task_runner.py:107} ERROR - Failed to execute job 4837 for task build_stac_task (Build STAC completed with 1 failures. See logs for details.; 1379)
[2025-06-17, 16:11:34 UTC] {local_task_job_runner.py:234} INFO - Task exited with return code 1
[2025-06-17, 16:11:34 UTC] {taskinstance.py:3312} INFO - 0 downstream tasks scheduled from follow-on schedule check
```

Successful run summary can be viewed here: https://sm2a.sit.openveda.cloud/dags/veda_dataset_pipeline/grid?run_id=manual__2025-06-17T16%3A04%3A38%2B00%3A00&execution_date=2025-06-17+16%3A04%3A38%2B00%3A00&tab=mapped_tasks&dag_run_id=manual__2025-06-17T00%3A03%3A55%2B00%3A00&task_id=build_stac_task&map_index=0

```
[2025-06-17, 00:04:39 UTC] {handler.py:105} INFO - === Starting build_stac for collection ida-ndwi-difference-test-reporting ===
[2025-06-17, 00:04:39 UTC] {handler.py:111} INFO - Total items to process is: 1
.
.
.
=== Run Summary ===
[2025-06-17, 00:04:40 UTC] {handler.py:139} INFO - Collection: ida-ndwi-difference-test-reporting
[2025-06-17, 00:04:40 UTC] {handler.py:140} INFO - Total Processed: 1
[2025-06-17, 00:04:40 UTC] {handler.py:141} INFO - Successes: 1
[2025-06-17, 00:04:40 UTC] {handler.py:142} INFO - Failures: 0
[2025-06-17, 00:04:40 UTC] {handler.py:143} INFO - Success Rate: 100.00%
[2025-06-17, 00:04:40 UTC] {handler.py:144} INFO - Duration: 1.07 seconds
[2025-06-17, 00:04:40 UTC] {handler.py:145} INFO - Processing Rate: 0.93 items/second
[2025-06-17, 00:04:40 UTC] {python.py:202} INFO - Done. Returned value was: {'payload': {'success_event_key': 's3://veda-tf-state-shared/events/ida-ndwi-difference-test-reporting/build_stac_output_05ab8ebf-df7f-4645-b82e-f8005a6f86da.json', 'failed_event_key': '', 'status': {'successes': 1, 'failures': 0}}}
[2025-06-17, 00:04:40 UTC] {taskinstance.py:1149} INFO - Marking task as SUCCESS. dag_id=veda_dataset_pipeline, task_id=build_stac_task, map_index=0, execution_date=20250617T000355, start_date=20250617T000438, end_date=20250617T000440
[2025-06-17, 00:04:40 UTC] {local_task_job_runner.py:234} INFO - Task exited with return code 0
[2025-06-17, 00:04:40 UTC] {taskinstance.py:3312} INFO - 1 downstream tasks scheduled from follow-on schedule check
```

## PR Checklist

- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
- [ ] Infrastructure changes - test using `terraform validate` and `terraform plan`