### PR TITLE
Trace dataset configs using Airflow Datasets/Assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,14 @@ else
 	$(call important_message, "Wait a minute you are not github 😡")
 endif
 
+sm2a-plan:
+	@echo "Installing the deployment dependency"
+	pip install -r ./deploy_requirements.txt
+	@echo "Shopwing Plan for Deploying SM2A"
+	python scripts/generate_env_file.py --secret-id ${SECRET_NAME} --env-file ${ENV_FILE}
+	@bash -c './scripts/deploy.sh ${ENV_FILE} <<< init'
+	@bash -c './scripts/deploy.sh ${ENV_FILE} <<< plan'
+
 clean: sm2a-local-stop
 	@echo "Cleaning local env"
 	docker container prune -f

--- a/airflow_services/Dockerfile
+++ b/airflow_services/Dockerfile
@@ -32,4 +32,4 @@ COPY --chown=airflow:airflow airflow_services/webserver_config.py "${AIRFLOW_HOM
 RUN cp ${AIRFLOW_HOME}/configuration/airflow.cfg* ${AIRFLOW_HOME}/.
 
 #ENV
-ENV PYTHONPATH /opt/airflow
+ENV PYTHONPATH="/opt/airflow"

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -4,6 +4,7 @@ import logging
 from copy import deepcopy
 import smart_open
 from airflow.models.variable import Variable
+from airflow.models.xcom import LazyXComSelectSequence
 from airflow.decorators import task
 from airflow.datasets import Dataset, DatasetAlias
 from airflow.datasets.metadata import Metadata
@@ -88,7 +89,7 @@ def build_stac_task(payload, ti=None):
             DatasetAlias("VEDA-Datasets")
         ],
 )
-def post_ingest_report(ti, logical_date):  # params are Airflow kwargs - use this task without input
+def post_ingest_dataset_event(ti, logical_date, built_items = {}):  # params are Airflow kwargs - use this task without input
     """
     Logs a Dataset event, saving the config used as a versioned object in s3, and creating a Metadata object visible in Airflow.
     
@@ -113,8 +114,22 @@ def post_ingest_report(ti, logical_date):  # params are Airflow kwargs - use thi
         json.dump(payload, f, indent=2)
     log_task(f"Payload written to {key}")
 
+    # built items can be either a dict or a list of dicts
+    if isinstance(built_items, LazyXComSelectSequence):
+        built_items = list(built_items)
+    elif not isinstance(built_items, list):
+        built_items = [built_items]
+    print(f"Built items: {built_items}")
+    success_count = sum(item.get("payload", {}).get("status", {}).get("successes", 0) for item in built_items)
+    failure_count = sum(item.get("payload", {}).get("status", {}).get("failures", 0) for item in built_items)
+
     yield Metadata(
         Dataset(f"{collection}"),
-        extra={"ingest_datetime": str(logical_date) },  # extra has to be provided, can be {}
+        extra={
+            "ingest_datetime": str(logical_date),
+            "ingest_configuration": key,
+            "successful_items": success_count,
+            "failed_items": failure_count,
+        },  # extra has to be provided, can be {}
         alias="VEDA-Datasets",
     )

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -115,6 +115,6 @@ def post_ingest_report(ti, logical_date):  # params are Airflow kwargs - use thi
 
     yield Metadata(
         Dataset(f"{collection}"),
-        extra={"ingest_datetime": logical_date },  # extra has to be provided, can be {}
+        extra={"ingest_datetime": str(logical_date) },  # extra has to be provided, can be {}
         alias="VEDA-Datasets",
     )

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -109,9 +109,13 @@ def post_ingest_dataset_event(ti, logical_date, built_items = {}):  # params are
         raise ValueError("Collection ID is required in the payload to create a report.")
     
     # write the payload to S3 as a versioned object
-    key = f"s3://{event_bucket_name}/airflow_events/{collection}/{logical_date.isoformat()}.json"
-    with smart_open.open(key, "w") as f:
-        json.dump(payload, f, indent=2)
+    key = f"s3://{event_bucket_name}/airflow_events/{collection}/{logical_date.format('YYYYMMDDHHmmss')}.json"
+    try:
+        with smart_open.open(key, "w") as f:
+            json.dump(payload, f, indent=2)
+    except Exception as e:
+        log_task(f"Error writing payload to {key}: {e}")
+        raise
     log_task(f"Payload written to {key}")
 
     # built items can be either a dict or a list of dicts

--- a/dags/veda_data_pipeline/groups/processing_tasks.py
+++ b/dags/veda_data_pipeline/groups/processing_tasks.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 import smart_open
 from airflow.models.variable import Variable
 from airflow.decorators import task
+from airflow.datasets import Dataset, DatasetAlias
+from airflow.datasets.metadata import Metadata
 from veda_data_pipeline.utils.submit_stac import submission_handler
 
 group_kwgs = {"group_id": "Process", "tooltip": "Process"}
@@ -80,3 +82,39 @@ def build_stac_task(payload, ti=None):
     airflow_vars_json = Variable.get("aws_dags_variables", deserialize_json=True)
     event_bucket = airflow_vars_json.get("EVENT_BUCKET")
     return stac_handler(payload_src=payload, bucket_output=event_bucket, ti=ti)
+
+@task(
+        outlets=[
+            DatasetAlias("VEDA-Datasets")
+        ],
+)
+def post_ingest_report(ti, logical_date):  # params are Airflow kwargs - use this task without input
+    """
+    Logs a Dataset event, saving the config used as a versioned object in s3, and creating a Metadata object visible in Airflow.
+    
+    Datasets are per-collection, with an alias of "VEDA-Datasets" for additional DAG triggers.
+
+    Args:
+        (Automatically populated by airflow when invoked)
+        ti: Airflow TaskInstance, used to access the DAG run configuration.
+        logical_date: The logical date of the DAG run, used for versioning.
+    Returns:
+        Yields a Metadata object that Airflow uses to register the Dataset event.
+    """
+    payload = ti.dag_run.conf
+    event_bucket_name = Variable.get("aws_dags_variables", deserialize_json=True).get("EVENT_BUCKET")
+    collection = payload.get("collection", None)
+    if not collection:
+        raise ValueError("Collection ID is required in the payload to create a report.")
+    
+    # write the payload to S3 as a versioned object
+    key = f"s3://{event_bucket_name}/airflow_events/{collection}/{logical_date.isoformat()}.json"
+    with smart_open.open(key, "w") as f:
+        json.dump(payload, f, indent=2)
+    log_task(f"Payload written to {key}")
+
+    yield Metadata(
+        Dataset(f"{collection}"),
+        extra={"ingest_datetime": logical_date },  # extra has to be provided, can be {}
+        alias="VEDA-Datasets",
+    )

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -4,7 +4,7 @@ from airflow.models.param import Param
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
 from airflow.operators.empty import EmptyOperator
 from veda_data_pipeline.groups.collection_group import collection_task_group
-from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset
+from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset, post_ingest_report
 
 template_dag_run_conf = {
     "collection": "<collection-id>",

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -53,4 +53,4 @@ with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as d
     discover = discover_from_s3_task.partial(payload=mutated_payloads).expand(event=discovery_items)
     get_files = get_files_task(payload=discover)
     build_stac = build_stac_task.expand(payload=get_files)
-    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> end
+    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> post_ingest_report() >> end

--- a/dags/veda_data_pipeline/veda_dataset_pipeline.py
+++ b/dags/veda_data_pipeline/veda_dataset_pipeline.py
@@ -4,7 +4,7 @@ from airflow.models.param import Param
 from veda_data_pipeline.groups.discover_group import discover_from_s3_task, get_files_task
 from airflow.operators.empty import EmptyOperator
 from veda_data_pipeline.groups.collection_group import collection_task_group
-from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset, post_ingest_report
+from veda_data_pipeline.groups.processing_tasks import submit_to_stac_ingestor_task, build_stac_task, extract_discovery_items_from_payload, remove_thumbnail_asset, post_ingest_dataset_event
 
 template_dag_run_conf = {
     "collection": "<collection-id>",
@@ -53,4 +53,4 @@ with DAG("veda_dataset_pipeline", params=template_dag_run_conf, **dag_args) as d
     discover = discover_from_s3_task.partial(payload=mutated_payloads).expand(event=discovery_items)
     get_files = get_files_task(payload=discover)
     build_stac = build_stac_task.expand(payload=get_files)
-    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> post_ingest_report() >> end
+    submit_stac = submit_to_stac_ingestor_task.expand(built_stac=build_stac) >> post_ingest_dataset_event(built_items=build_stac) >> end

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -91,7 +91,7 @@ check_create_remote_state $AWS_REGION $STATE_BUCKET_NAME $STATE_DYNAMO_TABLE
 read -rp 'action [init|plan|deploy]: ' ACTION
 case $ACTION in
   init)
-    terraform init -reconfigure
+    terraform init
     ;;
   plan)
     terraform plan

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -91,7 +91,7 @@ check_create_remote_state $AWS_REGION $STATE_BUCKET_NAME $STATE_DYNAMO_TABLE
 read -rp 'action [init|plan|deploy]: ' ACTION
 case $ACTION in
   init)
-    terraform init
+    terraform init -reconfigure
     ;;
   plan)
     terraform plan

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-AIRFLOW_VERSION=2.8.4
+AIRFLOW_VERSION=2.10.5
 
 pip install --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.11.txt" "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}"
 pip install -r sm2a/airflow_worker/requirements.txt "apache-airflow[celery,amazon]==${AIRFLOW_VERSION}"

--- a/scripts/run_task.py
+++ b/scripts/run_task.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
             Examples
             --------
             Initialize the db
-            $ python3 scripts/run_task.py --public-subnet-ids subnet-xxx --security-group sg-xxx --command 'db init'
+            $ python3 scripts/run_task.py --public-subnet-ids subnet-xxx --security-group sg-xxx --command 'db migrate --initialize'
 
             Create an admin user
             $ python3 scripts/run_task.py --public-subnet-ids subnet-xxx --security-group sg-xxx --command \\


### PR DESCRIPTION
**Summary:**

Addresses #370 

## Changes

- This PR is based on #318 in order to leverage Dataset Aliases.
- All ingests using the `veda-datasets` DAG will produce a Dataset event, which is correlated by collection ID.
- These events also write a manifest to s3 under the `event_bucket`
- In Airflow 3, the "Datasets" terminology changes to "Assets" - this is no less confusing for us, but explains the deprecation warnings introduced by this PR. We can revisit this if/when we upgrade to Airflow 3.

## PR Checklist

- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually (currently live on SIT)