### PR TITLE
Upgrade SM2A to 1.1.11

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,7 +26,7 @@ module "rds_backups" {
 
 
 module "sma-base" {
-  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.10/self-managed-apache-airflow.zip"
+  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.11/self-managed-apache-airflow.zip"
   project                        = var.project_name
   airflow_db                     = var.airflow_db
   fernet_key                     = var.fernet_key


### PR DESCRIPTION
Fixes deployment of secrets which already exist in some deployments.

## PR Checklist

- [ ] Unit tests
- [x] Ad-hoc testing - Successfully deployed alongside #318 on SIT - https://github.com/NASA-IMPACT/veda-deploy/actions/runs/15859782571/job/44716141743
- [ ] Integration tests
- [ ] Infrastructure changes - test using `terraform validate` and `terraform plan`