### PR TITLE
feat: remove vector security group inbound rule resource

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -110,13 +110,3 @@ module "sma-base" {
   }, var.snapshot_bucket_name != "" ? module.rds_backups[0].rds_backup_environment : {}
   )
 }
-
-resource "aws_vpc_security_group_ingress_rule" "vector_rds_ingress" {
-  count             = var.vector_security_group == "null" ? 0 : 1
-  security_group_id = var.vector_security_group
-
-  from_port                    = 5432
-  to_port                      = 5432
-  ip_protocol                  = "tcp"
-  referenced_security_group_id = module.sma-base.worker_security_group_id
-}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -159,11 +159,6 @@ variable "vector_secret_name" {
   default = "null"
 }
 
-variable "vector_security_group" {
-  type = string
-  default = "null"
-}
-
 variable "sm2a_secret_manager_name" {
   type    = string
   default = "null"


### PR DESCRIPTION
**Summary:**

Companion PR https://github.com/NASA-IMPACT/veda-features-api-cdk/pull/36
Related ticket https://github.com/NASA-IMPACT/veda-features-api-cdk/issues/16

## Changes

* This PR removes the resource that manages adding an inbound security group rule on behalf of the Airflow worker for the Vector/Features security group. We will be managing this resource in the features api repo. 

## PR Checklist

- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
- [ ] Infrastructure changes - test using `terraform validate` and `terraform plan`