### PR TITLE
update regex pattern

### DIFF
--- a/dags/veda_data_pipeline/utils/build_stac/utils/regex.py
+++ b/dags/veda_data_pipeline/utils/build_stac/utils/regex.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
 
+from . import events
 
 DATERANGE = Tuple[datetime, datetime]
 

--- a/dags/veda_data_pipeline/utils/build_stac/utils/regex.py
+++ b/dags/veda_data_pipeline/utils/build_stac/utils/regex.py
@@ -26,7 +26,7 @@ def _calculate_day_range(datetime_obj: datetime) -> DATERANGE:
     return start_datetime, end_datetime
 
 
-DATETIME_RANGE_METHODS: Dict[INTERVAL, Callable[[datetime], DATERANGE]] = {
+DATETIME_RANGE_METHODS: Dict[events.INTERVAL, Callable[[datetime], DATERANGE]] = {
     "month": _calculate_month_range,
     "year": _calculate_year_range,
     "day": _calculate_day_range,
@@ -34,7 +34,7 @@ DATETIME_RANGE_METHODS: Dict[INTERVAL, Callable[[datetime], DATERANGE]] = {
 
 
 def extract_dates(
-    filename: str, datetime_range: INTERVAL
+    filename: str, datetime_range: events.INTERVAL
 ) -> Union[Tuple[datetime, datetime, None], Tuple[None, None, datetime]]:
     """
     Extracts start & end or single date string from filename.

--- a/dags/veda_data_pipeline/utils/build_stac/utils/regex.py
+++ b/dags/veda_data_pipeline/utils/build_stac/utils/regex.py
@@ -4,7 +4,6 @@ from typing import Callable, Dict, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
 
-from . import events
 
 DATERANGE = Tuple[datetime, datetime]
 
@@ -27,7 +26,7 @@ def _calculate_day_range(datetime_obj: datetime) -> DATERANGE:
     return start_datetime, end_datetime
 
 
-DATETIME_RANGE_METHODS: Dict[events.INTERVAL, Callable[[datetime], DATERANGE]] = {
+DATETIME_RANGE_METHODS: Dict[INTERVAL, Callable[[datetime], DATERANGE]] = {
     "month": _calculate_month_range,
     "year": _calculate_year_range,
     "day": _calculate_day_range,
@@ -35,19 +34,19 @@ DATETIME_RANGE_METHODS: Dict[events.INTERVAL, Callable[[datetime], DATERANGE]] =
 
 
 def extract_dates(
-    filename: str, datetime_range: events.INTERVAL
+    filename: str, datetime_range: INTERVAL
 ) -> Union[Tuple[datetime, datetime, None], Tuple[None, None, datetime]]:
     """
     Extracts start & end or single date string from filename.
     """
     DATE_REGEX_STRATEGIES = [
-        (r"[_\.\-](\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})", "%Y-%m-%dT%H:%M:%S"),
-        (r"[_\.\-](\d{8}T\d{6})", "%Y%m%dT%H%M%S"),
-        (r"[_\.\-](\d{4}_\d{2}_\d{2})", "%Y_%m_%d"),
-        (r"[_\.\-](\d{4}-\d{2}-\d{2})", "%Y-%m-%d"),
-        (r"[_\.\-](\d{8})", "%Y%m%d"),
-        (r"[_\.\-](\d{6})", "%Y%m"),
-        (r"[_\.\-](\d{4})", "%Y"),
+        (r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})", "%Y-%m-%dT%H:%M:%S"),
+        (r"(\d{8}T\d{6})", "%Y%m%dT%H%M%S"),
+        (r"(\d{4}_\d{2}_\d{2})", "%Y_%m_%d"),
+        (r"(\d{4}-\d{2}-\d{2})", "%Y-%m-%d"),
+        (r"(\d{8})", "%Y%m%d"),
+        (r"(\d{6})", "%Y%m"),
+        (r"(\d{4})", "%Y"),
     ]
 
     # Find dates in filename


### PR DESCRIPTION
**Summary:**

Update regex pattern matching in `build_stac/utils/regex.py` to be more inclusive for dates that begin at the start of the filename. 

E.g., 20240914_DSWx-S1_BWTR.tif or 20240926_DSWx-S1_WTR.tif. Currently airflow will return an error stating that there is no valid datetime string found in the file.

## Changes

* Update regex to allow for dates to be found if they begin at the start of a string.

