### PR TITLE
fix: disable TF input in CI

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # Check .env file
 
-TF_INPUT=0
+export TF_INPUT=0
 
 DOT_ENV=$1
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 # Check .env file
 
+TF_INPUT=0
 
 DOT_ENV=$1
 


### PR DESCRIPTION
**Summary:**

Followup from concerns raised in [Slack](https://developmentseed.slack.com/archives/C045K5LAFA9/p1755630073994449) and observed during [update error](https://github.com/NASA-IMPACT/veda-data-airflow/issues/388#issuecomment-3208586370).

[Relevant TF Docs](https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS#auto-approval-of-plans)

[Hanging example](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/17114776510/job/48543427664#step:5:186) (current)
[Safely exit example](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/17114936050/job/48543865532#step:5:193) (proposed)

## Changes

* Disable input prompting during CI (`--input=false`)

## PR Checklist

- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
    - Delete `TF_VAR_rds_storage_encrypted` from sit deploy vars and dispatch
        Expect → `terraform apply` to fail without state breaking or partial changes applied
- [ ] Integration tests
- [ ] Infrastructure changes - test using `terraform validate` and `terraform plan`