### PR TITLE
Add error handling in stac creation and ingestion

### DIFF
--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -64,13 +64,13 @@ def handler(event: Dict[str, Any]) -> Union[S3LinkOutput, StacItemOutput]:
         stac_item = stac.generate_stac(parsed_event).to_dict()
     except Exception as ex:
         # Extract filename from first asset for better error reporting
-        filename = "unknown"
+        filename = None
         if event.get("assets"):
             first_asset = next(iter(event["assets"].values()), {})
             href = first_asset.get("href", "")
-            filename = href.split("/")[-1] if href else "unknown"
+            filename = href.split("/")[-1] if href else None
 
-        item_id = event.get("item_id", "unknown")
+        item_id = event.get("item_id", None)
         logging.error(f"Failed to generate STAC for file: {filename} (item_id: {item_id}) - Error: {ex}")
 
         out_err: StacItemOutput = {

--- a/dags/veda_data_pipeline/utils/build_stac/handler.py
+++ b/dags/veda_data_pipeline/utils/build_stac/handler.py
@@ -63,7 +63,24 @@ def handler(event: Dict[str, Any]) -> Union[S3LinkOutput, StacItemOutput]:
     try:
         stac_item = stac.generate_stac(parsed_event).to_dict()
     except Exception as ex:
-        out_err: StacItemOutput = {"stac_item": {"error": f"{ex}", "event": event}}
+        # Extract filename from first asset for better error reporting
+        filename = "unknown"
+        if event.get("assets"):
+            first_asset = next(iter(event["assets"].values()), {})
+            href = first_asset.get("href", "")
+            filename = href.split("/")[-1] if href else "unknown"
+
+        item_id = event.get("item_id", "unknown")
+        logging.error(f"Failed to generate STAC for file: {filename} (item_id: {item_id}) - Error: {ex}")
+
+        out_err: StacItemOutput = {
+            "stac_item": {
+                "error": f"{ex}",
+                "filename": filename,
+                "item_id": item_id,
+                "event": event
+            }
+        }
         return out_err
 
     output: StacItemOutput = {"stac_item": stac_item}
@@ -140,12 +157,34 @@ def stac_handler(payload_src: dict, bucket_output, ti=None):
         if payload_failures:
             logging.warning("\n=== Error Breakdown ===")
             error_breakdown = {}
+            failed_files_by_error = {}  # Track files per error type
+
             for failure in payload_failures:
                 error_msg = failure.get('error', 'Unknown error')
                 error_breakdown[error_msg] = error_breakdown.get(error_msg, 0) + 1
 
+                # Extract filename
+                filename = failure.get('filename', 'unknown')
+                if filename == 'unknown' and 'event' in failure:
+                    # Fallback: extract from event if not in failure directly
+                    assets = failure['event'].get('assets', {})
+                    if assets:
+                        first_asset = next(iter(assets.values()), {})
+                        href = first_asset.get('href', '')
+                        filename = href.split("/")[-1] if href else 'unknown'
+
+                # Group filenames by error
+                if error_msg not in failed_files_by_error:
+                    failed_files_by_error[error_msg] = []
+                failed_files_by_error[error_msg].append(filename)
+
             for error, count in error_breakdown.items():
                 logging.warning(f"  - {error}: {count} occurrences")
+                # Show up to 5 example filenames per error
+                example_files = failed_files_by_error[error][:5]
+                logging.warning(f"    Example files: {', '.join(example_files)}")
+                if len(failed_files_by_error[error]) > 5:
+                    logging.warning(f"    ... and {len(failed_files_by_error[error]) - 5} more")
 
         result = {
             "payload": {

--- a/dags/veda_data_pipeline/utils/submit_stac.py
+++ b/dags/veda_data_pipeline/utils/submit_stac.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import math
 import os
 import sys
 from dataclasses import dataclass
@@ -39,6 +41,29 @@ class Creds(TypedDict):
     expires_in: int
     token_type: str
     scope: str
+
+
+def sanitize_for_json(obj: Any) -> Any:
+    """
+    Recursively sanitize an object by replacing inf and NaN float values with None.
+    This ensures the object can be JSON serialized without errors.
+
+    Args:
+        obj: Any Python object (dict, list, float, etc.)
+
+    Returns:
+        Sanitized object with inf/NaN replaced by None
+    """
+    if isinstance(obj, dict):
+        return {key: sanitize_for_json(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [sanitize_for_json(item) for item in obj]
+    elif isinstance(obj, float):
+        if math.isnan(obj) or math.isinf(obj):
+            return None
+        return obj
+    else:
+        return obj
 
 @dataclass
 class IngestionApi:
@@ -86,16 +111,32 @@ class IngestionApi:
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
         }
-        response = requests.post(
-            f"{self.base_url.rstrip('/')}{endpoint}",
-            json=event,
-            headers=headers,
-        )
+
+        # Extract filename/item_id from the event for error reporting
+        item_id = event.get("id", "unknown")
+        filename = "unknown"
+        if "assets" in event:
+            assets = event.get("assets", {})
+            if assets:
+                first_asset = next(iter(assets.values()), {})
+                href = first_asset.get("href", "")
+                filename = href.split("/")[-1] if href else "unknown"
+
         try:
+            response = requests.post(
+                f"{self.base_url.rstrip('/')}{endpoint}",
+                json=event,
+                headers=headers,
+            )
             response.raise_for_status()
         except Exception as e:
-            print(response.text)
-            raise e
+            logging.error(f"Failed to submit STAC item. Item ID: {item_id}, Filename: {filename}, Error: {type(e).__name__}: {e}")
+            # Log response text if it's an HTTP error
+            if hasattr(e, 'response'):
+                resp = getattr(e, 'response')
+                if hasattr(resp, 'text'):
+                    logging.error(f"Response: {resp.text}")
+            raise
         return response.json()
 
 

--- a/dags/veda_data_pipeline/utils/submit_stac.py
+++ b/dags/veda_data_pipeline/utils/submit_stac.py
@@ -91,14 +91,14 @@ class IngestionApi:
         }
 
         # Extract filename/item_id from the event for error reporting
-        item_id = event.get("id", "unknown")
-        filename = "unknown"
+        item_id = event.get("id", None)
+        filename = None
         if "assets" in event:
             assets = event.get("assets", {})
             if assets:
                 first_asset = next(iter(assets.values()), {})
                 href = first_asset.get("href", "")
-                filename = href.split("/")[-1] if href else "unknown"
+                filename = href.split("/")[-1] if href else None
 
         try:
             response = requests.post(

--- a/dags/veda_data_pipeline/utils/submit_stac.py
+++ b/dags/veda_data_pipeline/utils/submit_stac.py
@@ -43,28 +43,6 @@ class Creds(TypedDict):
     scope: str
 
 
-def sanitize_for_json(obj: Any) -> Any:
-    """
-    Recursively sanitize an object by replacing inf and NaN float values with None.
-    This ensures the object can be JSON serialized without errors.
-
-    Args:
-        obj: Any Python object (dict, list, float, etc.)
-
-    Returns:
-        Sanitized object with inf/NaN replaced by None
-    """
-    if isinstance(obj, dict):
-        return {key: sanitize_for_json(value) for key, value in obj.items()}
-    elif isinstance(obj, list):
-        return [sanitize_for_json(item) for item in obj]
-    elif isinstance(obj, float):
-        if math.isnan(obj) or math.isinf(obj):
-            return None
-        return obj
-    else:
-        return obj
-
 @dataclass
 class IngestionApi:
     base_url: str


### PR DESCRIPTION
**Summary:**

Addresses #325 partially.  These proposed changes will add additional information regarding what the actual errors are and which files and ID's are associated with the file error. My current issue was only in the `submit_stac.py` which had the errors I've listed below. 

These changes improve the error reporting within Airflow and if the process is killed then the debugging process is made simpler.  I've also incorporated the same logging that was completed in #380 for `handler.py` which also has logging in case the stac creation process has error. 

## Changes

* Detailed list or prose of changes
Add additional logging.warnings into `handler.py` which prints filename that caused the issue.
Add logging.error in `submit_stac.py` which prints the ID and filename that caused the issue.
These log directly in Airflow.

See example below for the pre-logging error statement. 

```
[2025-10-09, 14:15:55 UTC] {taskinstance.py:3313} ERROR - Task failed with exception
```

See below for the new log errors statement. These are more interpretable.
```
[2025-10-09, 14:52:06 UTC] {submit_stac.py:133} ERROR - Failed to submit STAC item. Item ID: 202507_Flood_TX_CentralTX_S2_NDVI_Change_c2025-06-17_2025-07-17_day, Filename: 202507_Flood_TX_CentralTX_S2_NDVI_Change_c2025-06-17_2025-07-17_day.tif, Error: InvalidJSONError: Out of range float values are not JSON compliant
[2025-10-09, 14:56:55 UTC] {taskinstance.py:3313} ERROR - Task failed with exception
```

## PR Checklist

- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
- [ ] Infrastructure changes - test using `terraform validate` and `terraform plan`