### PR TITLE
Add policy statement for keycloak secrets

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -140,8 +140,18 @@ variable "custom_worker_policy_statement" {
         "arn:aws:secretsmanager:us-west-2:853558080719:secret:veda-keycloak*",
         "arn:aws:secretsmanager:us-west-2:114506680961:secret:veda-keycloak*"
       ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt"
+      ]
+      Resource = [
+        "arn:aws:kms:us-west-2:853558080719:key/*",
+        "arn:aws:kms:us-west-2:114506680961:key/*"
+      ]
     }
-
+  
   ]
 
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -151,7 +151,6 @@ variable "custom_worker_policy_statement" {
         "arn:aws:kms:us-west-2:114506680961:key/*"
       ]
     }
-  
   ]
 
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -130,6 +130,16 @@ variable "custom_worker_policy_statement" {
             "Effect": "Allow",
             "Action": ["cloudfront:CreateInvalidation"],
             "Resource": ["arn:aws:cloudfront::*:distribution/*"]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "secretsmanager:GetSecretValue"
+      ]
+      Resource = [
+        "arn:aws:secretsmanager:us-west-2:853558080719:secret:veda-keycloak*",
+        "arn:aws:secretsmanager:us-west-2:114506680961:secret:veda-keycloak*"
+      ]
     }
 
   ]
@@ -167,6 +177,12 @@ variable "vector_security_group" {
 variable "sm2a_secret_manager_name" {
   type    = string
   default = "null"
+}
+
+variable "secrets_manager_arns" {
+  type        = list(string)
+  description = "List of Secrets Manager ARNs that workers can access"
+  default     = []
 }
 
 variable "workers_cpu" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -147,8 +147,7 @@ variable "custom_worker_policy_statement" {
         "kms:Decrypt"
       ]
       Resource = [
-        "arn:aws:kms:us-west-2:853558080719:key/*",
-        "arn:aws:kms:us-west-2:114506680961:key/*"
+        "arn:aws:kms:us-west-2:853558080719:key/360b41aa-0c14-4d64-a213-fb7c7ac83cd7"
       ]
     }
   ]

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -189,12 +189,6 @@ variable "sm2a_secret_manager_name" {
   default = "null"
 }
 
-variable "secrets_manager_arns" {
-  type        = list(string)
-  description = "List of Secrets Manager ARNs that workers can access"
-  default     = []
-}
-
 variable "workers_cpu" {
   default = 2048
 }


### PR DESCRIPTION
Companion PR for this keycloak PR: https://github.com/NASA-IMPACT/veda-keycloak/pull/100

The secrets manager policy for the dev and prod keycloaks are hard coded along with a `veda-keycloak` wildcard prefix. This was the simplest way to do it instead of adding separate variables for each account (dev and prod) which would be difficult to reference inside the `custom_worker_policy_statement` variable.