### PR TITLE
chore: bump source module to fix prod url

### DIFF
--- a/.github/actions/terraform-deploy-sm2a/action.yml
+++ b/.github/actions/terraform-deploy-sm2a/action.yml
@@ -28,7 +28,6 @@ inputs:
     - plan
     - apply
 
-concurrency: ${{ inputs.env_aws_secret_name }}
 
 runs:
   using: "composite"

--- a/.github/actions/terraform-deploy-sm2a/action.yml
+++ b/.github/actions/terraform-deploy-sm2a/action.yml
@@ -28,6 +28,7 @@ inputs:
     - plan
     - apply
 
+concurrency: ${{ inputs.env_aws_secret_name }}
 
 runs:
   using: "composite"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,6 +70,7 @@ jobs:
     if: ${{ !needs.define-environment.outputs.env_name }}
     needs: [gitflow-enforcer, define-environment]
     environment: development
+    concurrency: development
 
     steps:
       - name: Checkout

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,7 +26,7 @@ module "rds_backups" {
 
 
 module "sma-base" {
-  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.13/self-managed-apache-airflow.zip"
+  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.1.14/self-managed-apache-airflow.zip"
   project                        = var.project_name
   airflow_db                     = var.airflow_db
   fernet_key                     = var.fernet_key
@@ -83,16 +83,17 @@ module "sma-base" {
     }
   ]
   extra_airflow_configuration = {
-    keycloak_base_url    = var.keycloak_base_url
-    keycloak_realm       = var.keycloak_realm
-    keycloak_client_id  = var.keycloak_client_id
+    keycloak_base_url      = var.keycloak_base_url
+    keycloak_realm         = var.keycloak_realm
+    keycloak_client_id     = var.keycloak_client_id
     keycloak_client_secret = var.keycloak_client_secret
-    sm2a_base_url        = "https://${lower(var.subdomain)}.${var.domain_name}"
+    sm2a_base_url          = "https://${lower(var.subdomain)}.${var.domain_name}"
   }
-  domain_name = var.domain_name
-  stage       = var.stage
-  subdomain   = var.subdomain
-  worker_cmd  = ["airflow", "celery", "worker"]
+  domain_name  = var.domain_name
+  stage        = var.stage
+  subdomain    = var.subdomain
+  customdomain = var.customdomain
+  worker_cmd   = ["airflow", "celery", "worker"]
 
   # add custom env, with conditional rds backup env vars
   airflow_custom_variables = merge({

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -75,7 +75,7 @@ variable "keycloak_base_url" {
 }
 
 variable "keycloak_realm" {
-    
+
 }
 
 variable "keycloak_client_id" {
@@ -281,5 +281,11 @@ variable "rds_storage_encrypted" {
 
 variable "rds_snapshot_identifier" {
   description = "Snapshot from which to create Airflow RDS instance"
+  default     = null
+}
+
+variable "customdomain" {
+  description = "Optional custom domain for ALB host header and certificate. If provided, overrides default subdomain.domain_name logic"
+  type        = string
   default     = null
 }


### PR DESCRIPTION
**Summary:**

The SM2A source module previously made stricter assumptions to build a `{prefix}.{stage}.{root}` URL per deployment, but we drop the stage indicator in production for a shorter, cleaner URL (compared to preprod envs). 

Source module has been [updated](https://github.com/NASA-IMPACT/self-managed-apache-airflow/pull/34) to support greater flexibility in domain name yield.

## Changes

* Bump source SM2A module for added domain name flexibility

## PR Checklist

- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
- [x] Infrastructure changes - test using `terraform validate` and `terraform plan`
    - See [plan run](https://github.com/NASA-IMPACT/veda-data-airflow/actions/runs/23272380173/job/67667855776?pr=429#step:4:373) using new `customdomain` var → changes certificates + listener rule, eg:
    ```diff
    # module.sma-base.module.ecs_services.aws_alb_listener_rule.ecs-alb-listener-role will be updated in-place
    ~ resource "aws_alb_listener_rule" "ecs-alb-listener-role" {
    ...
    +   condition {
    +       host_header {
    +           values = [
    +               "foo.openveda.cloud",
    +           ]
    +       }
    +   }
    -   condition {
    -       host_header {
    -           values = [
    -               "sm2a.dev.openveda.cloud",
    -           ] -> null
    -       }
    -   }
    }
    ```
    - Modify `veda-sm2a-dev-deployment-secrets` for further review testing