### PR TITLE
fix: declare new alb logging vars

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -289,3 +289,15 @@ variable "customdomain" {
   type        = string
   default     = null
 }
+
+variable "alb_access_logs_bucket" {
+  description = "S3 bucket name for ALB access logs"
+  type        = string
+  default     = null
+}
+
+variable "alb_access_logs_prefix" {
+  description = "S3 key prefix for ALB access logs"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
**Summary:**

Fix missing variable declaration for new module variables (supporting ALB access logging)
