### PR TITLE
security: prevent arbitrary table deletion in veda_vector_delete DAG

### DIFF
--- a/dags/veda_data_pipeline/veda_vector_delete.py
+++ b/dags/veda_data_pipeline/veda_vector_delete.py
@@ -72,7 +72,7 @@ def delete_from_featuresdb(**kwargs):
         password=conn_secrets["password"],
     )
 
-    if collection in ["spatial_ref_sys","geometry_columns","geography_columns"]:
+    if collection in ["spatial_ref_sys","geometry_columns","geography_columns", "admin_table", "user"]:
         raise ValueError(
             f"Programmatic deletion should only be used for collection tables. ",
             "`{collection}` is a PostGIS reference table, terminating operation."


### PR DESCRIPTION
The veda_vector_delete.py DAG allows specifying a collection_name via dag_run.conf. This is used in a DROP TABLE ... CASCADE statement. While sql.Identifier is used, the lack of value-level validation allows an authorized user to delete any table in the database. Verified via Docker PoC (Node 04) by successfully deleting a protected admin table.