### PR TITLE
feat: add veda-data-airflow versioning to ui

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -109,6 +109,11 @@ jobs:
         with:
           lfs: "true"
           submodules: "recursive"
+          fetch-depth: 0
+
+      - name: Get latest release tag
+        id: get_tag
+        run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo 'unknown')" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 #v2.2.0
@@ -121,6 +126,9 @@ jobs:
         # Flag to deploy SM2A
         if: ${{ vars.DEPLOY_SM2A }} = "true"
         uses: "./.github/actions/terraform-deploy-sm2a"
+        env:
+          TF_VAR_veda_airflow_version: ${{ steps.get_tag.outputs.tag }}
+          TF_VAR_git_sha: ${{ github.sha }}
         with:
           dir: .
           env_aws_secret_name: ${{ vars.SM2A_ENVS_DEPLOYMENT_SECRET_NAME }}

--- a/airflow_services/templates/airflow/main.html
+++ b/airflow_services/templates/airflow/main.html
@@ -1,0 +1,138 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+{% extends 'appbuilder/baselayout.html' %}
+{% from 'airflow/_messages.html' import show_message %}
+
+{% block page_title -%}
+  {% if title is defined -%}
+    {{ title }} - {{ appbuilder.app_name }}
+  {% else -%}
+    {{ appbuilder.app_name }}
+  {% endif%}
+{% endblock %}
+
+{% block head_meta %}
+  {{ super() }}
+  {% if scheduler_job is defined and (scheduler_job and scheduler_job.is_alive()) %}
+    <meta name="is_scheduler_running" content="True">
+  {% endif %}
+{% endblock %}
+
+{% block head_css %}
+  {{ super() }}
+
+  {% if not appbuilder.app_theme %}
+    {# airflowDefaultTheme.css file contains the styles from local bootstrap-theme.css #}
+    <link rel="stylesheet" type="text/css" href="{{ url_for_asset('airflowDefaultTheme.css') }}">
+  {% endif %}
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('materialIcons.css') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('main.css') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('loadingDots.css') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('bootstrap-datetimepicker.min.css') }}">
+  <style type="text/css">
+    {% for state, state_color in state_color_mapping.items() %}
+      span.{{state}} {
+        background-color: {{state_color}};
+      }
+    {% endfor %}
+    .navbar-nav > li > a {
+      color: {{ navbar_text_color }};
+    }
+    .navbar-nav > li > a:hover {
+      background-color:  {{ navbar_hover_color }};
+      color: {{ navbar_text_hover_color }};
+    }
+  </style>
+  <link rel="icon" type="image/png" href="{{ url_for('static', filename='pin_32.png') }}">
+{% endblock %}
+
+{% block messages %}
+  {% include 'appbuilder/flash.html' %}
+  {% if scheduler_job is defined and (not scheduler_job or not scheduler_job.is_alive()) %}
+    {% call show_message(category='warning', dismissible=false) %}
+      <p>The scheduler does not appear to be running.
+      {% if scheduler_job %}
+      Last heartbeat was received
+      <time class="scheduler-last-heartbeat"
+        title="{{ scheduler_job.latest_heartbeat.isoformat() }}"
+        datetime="{{ scheduler_job.latest_heartbeat.isoformat() }}"
+        data-datetime-convert="false"
+      >{{ macros.datetime_diff_for_humans(scheduler_job.latest_heartbeat) }}</time>.
+      {% endif %}
+      </p>
+      <p>The DAGs list may not update, and new tasks will not be scheduled.</p>
+    {% endcall %}
+  {% endif %}
+  {% if triggerer_job is defined and (not triggerer_job or not triggerer_job.is_alive()) %}
+    {% call show_message(category='warning', dismissible=false) %}
+      <p>The triggerer does not appear to be running.
+      {% if triggerer_job %}
+      Last heartbeat was received
+      <time class="scheduler-last-heartbeat"
+        title="{{ triggerer_job.latest_heartbeat.isoformat() }}"
+        datetime="{{ triggerer_job.latest_heartbeat.isoformat() }}"
+        data-datetime-convert="false"
+      >{{ macros.datetime_diff_for_humans(triggerer_job.latest_heartbeat) }}</time>.
+      {% endif %}
+      </p>
+      <p>Triggers will not run, and any deferred operator will remain deferred until it times out and fails.</p>
+    {% endcall %}
+  {% endif %}
+{% endblock %}
+
+{% block footer %}
+  {% if auth_manager.is_logged_in() %}
+    <footer class="footer">
+      <div class="container">
+        <div>
+          Airflow Version: {% if airflow_version %}<a href="https://pypi.python.org/pypi/apache-airflow/{{ airflow_version }}" target="_blank" rel="noopener noreferrer">v{{ airflow_version }}</a>{% else %} N/A{% endif %}
+          {% if git_version %}<br>Git Version: <strong>{{ git_version }}</strong>{% endif %}
+        </div>
+        <div>
+          Veda Version: {{ veda_airflow_version }} {% if deployment_git_sha %} | SHA: {{ deployment_git_sha }}{% endif %}
+        </div>
+      </div>
+    </footer>
+  {% endif %}
+{% endblock %}
+
+{% block tail_js %}
+  {{ super() }}
+  <script>
+    // below variables are used in main.js
+    // keep as var, changing to const or let breaks other code
+    var Airflow = {
+      serverTimezone: '{{ server_timezone }}',
+      defaultUITimezone: '{{ default_ui_timezone }}',
+    };
+    var hostName = '{{ hostname }}';
+    var csrfToken = '{{ csrf_token() }}';
+    $('time[title]').tooltip();
+  </script>
+  <script src="{{ url_for_asset('moment.js') }}"></script>
+  <script src="{{ url_for_asset('main.js') }}"></script>
+  <script src="{{ url_for_asset('bootstrap-datetimepicker.min.js') }}"></script>
+  <script src="{{ url_for_asset('bootstrap3-typeahead.min.js') }}"></script>
+  <script src="{{ url_for_asset('toggleTheme.js') }}"></script>
+
+  {% if analytics_tool is defined and analytics_tool %}
+    {% include "analytics/" + analytics_tool + ".html" %}
+  {% endif %}
+{% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ x-airflow-common:
     - ./plugins:/opt/airflow/plugins
     - ./sm2a-local-config/local_airflow.cfg:/opt/airflow/airflow.cfg
     - ./sm2a-local-config/local_webserver_config.py:/opt/airflow/webserver_config.py
+    - ./airflow_services/templates/airflow/main.html:/home/airflow/.local/lib/python3.11/site-packages/airflow/www/templates/airflow/main.html
     - ./infrastructure/configuration:/opt/airflow/configuration
     - ./scripts:/opt/airflow/scripts
   user: "50000:0"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -106,6 +106,14 @@ module "sma-base" {
       {
         name  = "KEYCLOAK_CLIENT_SECRET"
         value = var.keycloak_client_secret
+      },
+      {
+        name  = "VEDA_AIRFLOW_VERSION"
+        value = var.veda_airflow_version
+      },
+      {
+        name  = "GIT_SHA"
+        value = var.git_sha
       }
     ],
     local.airflow_dag_variable_env_entries

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -279,3 +279,15 @@ variable "alb_access_logs_prefix" {
   type        = string
   default     = null
 }
+
+variable "veda_airflow_version" {
+  description = "Deployed version tag of veda-data-airflow"
+  type        = string
+  default     = "unknown"
+}
+
+variable "git_sha" {
+  description = "Deployed git commit SHA of veda-data-airflow"
+  type        = string
+  default     = "unknown"
+}

--- a/plugins/display_version.py
+++ b/plugins/display_version.py
@@ -1,0 +1,20 @@
+import os
+from flask import Blueprint
+from airflow.plugins_manager import AirflowPlugin
+
+bp = Blueprint("display_version_bp", __name__)
+
+
+@bp.app_context_processor
+def _deployment_context():
+    veda_airflow_version = os.getenv("VEDA_AIRFLOW_VERSION", "")
+    git_sha = os.getenv("GIT_SHA", "")
+    return {
+        "veda_airflow_version": veda_airflow_version if veda_airflow_version else "unknown",
+        "deployment_git_sha": git_sha[:7] if git_sha else "unknown",
+    }
+
+
+class DisplayVersionPlugin(AirflowPlugin):
+    name = "display_version"
+    flask_blueprints = [bp]


### PR DESCRIPTION
**Ticket:** https://github.com/NASA-IMPACT/veda-data-airflow/issues/413

**Note:**  This was a bit more involved and trickier than I thought it would be since I had to track where the HTML was coming from and had to opt for mounting a local version instead so we could add the extra version details for the footer. It looked like we weren't getting the git tags and versions already either so I had to update our git workflow and add these variables to terraform 🤔. The screen shot is just grabbing from my local env file. Let me know if this could have been done another way though?? 

**Changes**

* Added local version of `/templates/main.html` file to override the default version in `v2.10.5` (default version [here](https://github.com/apache/airflow/blob/2.10.5/airflow/www/templates/airflow/main.html)) and have docker mount this instead
   * Added `display_version` plugin so version variables can be referenced in template https://flask.palletsprojects.com/en/stable/templating/#context-processors
* Added `Get latest release tag` step in git workflow to grab the git tag and register with terraform so release versions are available to ECS task

<img width="743" height="859" alt="Screenshot 2026-06-17 at 11 57 38 AM" src="https://github.com/user-attachments/assets/776d3daf-dd70-493f-86e0-c1766cff3349" />