### PR TITLE
ci: security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "terraform"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "build(deps):"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,7 +1,6 @@
 name: CICD 🚀
 
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -71,6 +70,8 @@ jobs:
     needs: [gitflow-enforcer, define-environment]
     environment: development
     concurrency: development
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout
@@ -102,6 +103,8 @@ jobs:
     needs: [gitflow-enforcer, define-environment]
     environment: ${{ needs.define-environment.outputs.env_name }}
     concurrency: ${{ needs.define-environment.outputs.env_name }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 #v5.4.2
         name: Setup uv
         with:
           python-version: 3.11

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 16 * * 1" # Monday 10:30/11:30 CT
+
+permissions: read-all # Default all to readonly
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Allow upload to Security dashboard
+      id-token: write # Access GitHub's OIDC token to verify authenticity of result for publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create release
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
>[!NOTE]
>See https://github.com/NASA-IMPACT/veda-keycloak/pull/253 for more detail on OSSF Scorecard + Dependabot configs, removed repeated detail to help reviewers and better highlight repo-specific deltas.

---

- Dependabot version updates added:
    - `uv` (DAG Dependencies)
    - `docker` (service container images)
    - `terraform` (infrastructure)
        - Investigatory, may be removed
    - `github-actions` (CI)
- Commit SHAs
    - `setup-uv`: pinned to version used in last workflow run
    - `checkout` (test-dags job): pinned to match deploy for greater parity between test + deploy conditions
- [OSSF Scorecard](https://github.com/ossf/scorecard-action) added
- Token permissions
    - Move write permissions from top-level (all jobs) to specific job required