### PR TITLE
Fix: metrics fix + queue timeout increase

### DIFF
--- a/infrastructure/configuration/celery_config.py
+++ b/infrastructure/configuration/celery_config.py
@@ -5,19 +5,10 @@ from airflow.providers.celery.executors.default_celery import DEFAULT_CELERY_CON
 # From here https://github.com/apache/airflow/issues/16163
 # DEFAULT_CELERY_CONFIG['task_acks_late'] = False
 
-# Must exceed the runtime of the longest task. If SQS makes a message visible
-# again while its task is still running, the message is redelivered and a second
-# worker tries to start the same task instance. On Airflow 3 the Task Execution
-# API rejects that second start with `invalid_state`, the Celery executor reports
-# the task as failed, and the scheduler then kills the healthy original run --
-# the task fails despite never having errored.
-#
-# NOTE: this alone is not sufficient. Because `predefined_queues` is set below,
-# kombu does not create the queue, and the SQS queue's own VisibilityTimeout
-# attribute governs redelivery. That attribute must be raised to match (it is
-# created at the AWS default of 30s by the sm2a module, which does not set
-# aws_sqs_queue.visibility_timeout_seconds).
-VISIBILITY_TIMEOUT = 21600  # 6h; SQS allows up to 43200
+# Must exceed the longest task runtime, or SQS redelivers mid-run and the duplicate
+# delivery fails the task on Airflow 3. The queue's own VisibilityTimeout attribute
+# must match, since predefined_queues means kombu does not create the queue.
+VISIBILITY_TIMEOUT = 1800  # 30m; SQS allows up to 43200
 
 CELERY_CONFIG = {
     **DEFAULT_CELERY_CONFIG,

--- a/infrastructure/configuration/celery_config.py
+++ b/infrastructure/configuration/celery_config.py
@@ -4,12 +4,26 @@ from airflow.providers.celery.executors.default_celery import DEFAULT_CELERY_CON
 
 # From here https://github.com/apache/airflow/issues/16163
 # DEFAULT_CELERY_CONFIG['task_acks_late'] = False
-# DEFAULT_CELERY_CONFIG['broker_transport_options']['visibility_timeout'] = 300
+
+# Must exceed the runtime of the longest task. If SQS makes a message visible
+# again while its task is still running, the message is redelivered and a second
+# worker tries to start the same task instance. On Airflow 3 the Task Execution
+# API rejects that second start with `invalid_state`, the Celery executor reports
+# the task as failed, and the scheduler then kills the healthy original run --
+# the task fails despite never having errored.
+#
+# NOTE: this alone is not sufficient. Because `predefined_queues` is set below,
+# kombu does not create the queue, and the SQS queue's own VisibilityTimeout
+# attribute governs redelivery. That attribute must be raised to match (it is
+# created at the AWS default of 30s by the sm2a module, which does not set
+# aws_sqs_queue.visibility_timeout_seconds).
+VISIBILITY_TIMEOUT = 21600  # 6h; SQS allows up to 43200
 
 CELERY_CONFIG = {
     **DEFAULT_CELERY_CONFIG,
     "broker_transport_options": {
         **DEFAULT_CELERY_CONFIG["broker_transport_options"],
+        "visibility_timeout": VISIBILITY_TIMEOUT,
         "predefined_queues": {
             # Gotcha: kombu.transport.SQS.UndefinedQueueException
             # Queue with name 'default' must be defined in 'predefined_queues'

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -50,7 +50,7 @@ locals {
 }
 
 module "sma-base" {
-  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.2.0-rc4/self-managed-apache-airflow.zip"
+  source                         = "https://github.com/NASA-IMPACT/self-managed-apache-airflow/releases/download/v1.2.0-rc5/self-managed-apache-airflow.zip"
   project                        = var.project_name
   airflow_db                     = var.airflow_db
   fernet_key                     = var.fernet_key

--- a/scripts/put_airflow_worker_autoscaling_metric_data.py
+++ b/scripts/put_airflow_worker_autoscaling_metric_data.py
@@ -178,7 +178,9 @@ def get_task_count_where_state(states: List[str]) -> int:
             session.query(func.sum(tasks_query.c.count))
             .join(DagModel, DagModel.dag_id == tasks_query.c.dag_id)
             .filter(
-                DagModel.is_active.is_(True),
+                # Airflow 3 removed the DagModel.is_active column; is_stale is its
+                # inverse (a DAG missing from its bundle is marked stale).
+                DagModel.is_stale.is_(False),
                 DagModel.is_paused.is_(False),
             )
             .scalar()


### PR DESCRIPTION
Fix a deprecation in the metrics container. Also increase the default queue timeout - this was impacting backfill tasks, which were taking extra time as a result of migrating in the middle of a fires ingest. There will be an upstream PR to align the SQS settings with this new value - https://github.com/NASA-IMPACT/self-managed-apache-airflow/pull/40

The timeout change has already been applied to dev via the console.