### PR TITLE
Add optional post-ingest table configuration to veda_ingest_vector

### DIFF
--- a/dags/veda_data_pipeline/utils/vector_ingest/README.md
+++ b/dags/veda_data_pipeline/utils/vector_ingest/README.md
@@ -34,7 +34,53 @@ Depending on how the data needs to be ingested, different approaches can be take
 
 ---
 
-### 3. Internal Processing with ogr2ogr
+### 3. Configuring the Table (Optional)
+After **every** discovered file has been ingested, an optional `table_config` block applies
+index and statistics DDL to the collection. Omit the key entirely to skip this step.
+
+```json
+{
+  "collection": "hms_smoke",
+  "table_config": {
+    "schema": "public",
+    "indexes": [
+      {"columns": ["datetime"], "method": "btree", "concurrently": true}
+    ],
+    "analyze": true
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `schema` | Table schema, default `public`. |
+| `indexes` | List of indexes. Each needs `columns`; `method` (default `btree`), `concurrently` (default `true`) and `name` are optional. |
+| `analyze` | Run `ANALYZE` afterwards, default `true`. Without statistics the planner will not use the new indexes. |
+
+**Why this runs after ingest, not before.** Building an index in one bulk sort is cheaper
+than maintaining it row by row while data loads. The task sits downstream of the mapped
+ingest tasks, so it runs once on the finished table rather than once per file.
+
+**Notes**
+
+- Requires an explicit `collection`. With a per-file `id_template` there is no single
+  table to configure and the step is skipped.
+- `ogr2ogr` already creates the GiST index on the geometry column and has no option for
+  an index on any other column; this covers the rest.
+- `-overwrite` drops and recreates the table, destroying its indexes, so they are rebuilt
+  on each ingest.
+- `concurrently` defaults to `true` so the build does not hold an `ACCESS EXCLUSIVE` lock
+  on a table the Features API is serving — a blocking build on a large table is a visible
+  outage, not just a slow ingest.
+- **Backfilling across several DAG runs:** omit `table_config` from the intermediate runs
+  and set it only on the last one. Otherwise the index is created after the first run and
+  every later chunk loads into an indexed table, which is exactly what the post-ingest
+  ordering is meant to avoid. Within a *single* run this is handled automatically, since
+  all files are ingested by mapped tasks before this step runs.
+
+---
+
+### 4. Internal Processing with ogr2ogr
 Internally, the ingestion task uses the **ogr2ogr** command, a command-line tool from the **GDAL** library, to convert and process geospatial data between various formats. The data is imported into a **PostgreSQL** database with **PostGIS** extensions for spatial data.
 
 #### **Supported Input Formats**

--- a/dags/veda_data_pipeline/utils/vector_ingest/table_config.py
+++ b/dags/veda_data_pipeline/utils/vector_ingest/table_config.py
@@ -120,14 +120,44 @@ def find_invalid_indexes(cursor, collection: str, schema: str = "public") -> lis
     return [row[0] for row in cursor.fetchall()]
 
 
+def run_statements(conn, collection: str, table_config: dict) -> dict:
+    """Execute a table_config against an open connection.
+
+    Separated from secret lookup so this can be pointed at any Postgres -- a local
+    container, a test fixture -- without AWS.
+    """
+    statements = build_statements(collection, table_config)
+    if not statements:
+        print("No table_config provided, skipping table configuration")
+        return {"status": "skipped", "statements": []}
+
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    conn.autocommit = True
+
+    with conn.cursor() as cursor:
+        for statement in statements:
+            print(f"Running: {statement}")
+            cursor.execute(statement)
+
+        invalid = find_invalid_indexes(
+            cursor, collection, table_config.get("schema", "public")
+        )
+        if invalid:
+            print(
+                f"WARNING: invalid indexes on {collection} (likely an interrupted "
+                f"CONCURRENTLY build); drop and recreate them: {invalid}"
+            )
+
+    return {"status": "success", "statements": statements}
+
+
 def apply_table_config(collection: str, table_config: dict, vector_secret_name: str) -> dict:
     """Run the table_config statements against the features database."""
     import psycopg2
 
     from veda_data_pipeline.utils.vector_ingest.handler import get_secret
 
-    statements = build_statements(collection, table_config)
-    if not statements:
+    if not build_statements(collection, table_config):
         print("No table_config provided, skipping table configuration")
         return {"status": "skipped", "statements": []}
 
@@ -138,24 +168,7 @@ def apply_table_config(collection: str, table_config: dict, vector_secret_name: 
         user=secrets["username"],
         password=secrets["password"],
     )
-    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
-    conn.autocommit = True
-
     try:
-        with conn.cursor() as cursor:
-            for statement in statements:
-                print(f"Running: {statement}")
-                cursor.execute(statement)
-
-            invalid = find_invalid_indexes(
-                cursor, collection, table_config.get("schema", "public")
-            )
-            if invalid:
-                print(
-                    f"WARNING: invalid indexes on {collection} (likely an interrupted "
-                    f"CONCURRENTLY build); drop and recreate them: {invalid}"
-                )
+        return run_statements(conn, collection, table_config)
     finally:
         conn.close()
-
-    return {"status": "success", "statements": statements}

--- a/dags/veda_data_pipeline/utils/vector_ingest/table_config.py
+++ b/dags/veda_data_pipeline/utils/vector_ingest/table_config.py
@@ -1,0 +1,161 @@
+"""Apply post-ingest table configuration (indexes, statistics) to a vector collection.
+
+Indexes are deliberately created *after* the data is loaded: building a B-tree in one
+bulk sort is cheaper than maintaining it row by row during ingest. The task that calls
+this therefore sits downstream of the mapped ingest tasks, so it runs once after every
+chunk has landed rather than once per chunk.
+
+For a backfill split across several DAG runs, omit ``table_config`` from the conf of the
+intermediate runs and include it only on the last one -- otherwise the index exists while
+the remaining chunks are still loading, which is the case this ordering exists to avoid.
+
+``ogr2ogr`` already creates the GiST index on the geometry column, and has no option for
+an index on any other column. This covers the rest.
+"""
+
+import re
+
+# Postgres identifiers as produced by ogr2ogr: lower-case alphanumerics and underscores.
+# Anything else is rejected rather than escaped, so a surprising name fails loudly
+# instead of being quietly quoted into a statement.
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Index methods worth allowing here. `method` reaches SQL as a bare keyword, so it is
+# checked against this set rather than quoted.
+ALLOWED_INDEX_METHODS = frozenset({"btree", "gist", "brin", "gin", "hash", "spgist"})
+
+MAX_IDENTIFIER_LENGTH = 63  # Postgres truncates beyond this, silently
+
+
+class InvalidTableConfig(ValueError):
+    """Raised when a table_config block cannot be turned into safe SQL."""
+
+
+def _identifier(value: str, kind: str) -> str:
+    """Validate a Postgres identifier and return it double-quoted."""
+    if not isinstance(value, str) or not IDENTIFIER_RE.match(value):
+        raise InvalidTableConfig(
+            f"invalid {kind}: {value!r} -- expected letters, digits and underscores"
+        )
+    return f'"{value}"'
+
+
+def index_name(table: str, columns: list, method: str) -> str:
+    """Build a deterministic index name, so re-runs are genuine no-ops.
+
+    Truncated to Postgres' identifier limit; without this a long table plus several
+    columns silently produces a different name than `IF NOT EXISTS` looks for, and the
+    index gets rebuilt on every run.
+    """
+    name = f"idx_{table}_{'_'.join(columns)}"
+    if method != "btree":
+        name = f"{name}_{method}"
+    return name[:MAX_IDENTIFIER_LENGTH]
+
+
+def build_statements(collection: str, table_config: dict) -> list:
+    """Turn a table_config block into the SQL statements that apply it.
+
+    Kept separate from execution so the generated SQL can be tested without a database.
+    """
+    if not table_config:
+        return []
+
+    schema = table_config.get("schema", "public")
+    schema_sql = _identifier(schema, "schema")
+    table_sql = _identifier(collection, "collection")
+    qualified = f"{schema_sql}.{table_sql}"
+
+    statements = []
+    for index in table_config.get("indexes", []):
+        columns = index.get("columns")
+        if not columns:
+            raise InvalidTableConfig(f"index entry has no columns: {index!r}")
+
+        method = index.get("method", "btree").lower()
+        if method not in ALLOWED_INDEX_METHODS:
+            raise InvalidTableConfig(
+                f"unsupported index method {method!r}; "
+                f"expected one of {sorted(ALLOWED_INDEX_METHODS)}"
+            )
+
+        columns_sql = ", ".join(_identifier(column, "column") for column in columns)
+        name = index.get("name") or index_name(collection, columns, method)
+
+        # CONCURRENTLY avoids the ACCESS EXCLUSIVE lock that would otherwise block reads
+        # for the whole build -- on a large table being served by the features API that
+        # is a visible outage, not just a slow ingest.
+        concurrently = "CONCURRENTLY " if index.get("concurrently", True) else ""
+
+        statements.append(
+            f"CREATE INDEX {concurrently}IF NOT EXISTS {_identifier(name, 'index name')} "
+            f"ON {qualified} USING {method} ({columns_sql})"
+        )
+
+    if table_config.get("analyze", True):
+        # Without statistics the planner will not use the indexes just created.
+        statements.append(f"ANALYZE {qualified}")
+
+    return statements
+
+
+def find_invalid_indexes(cursor, collection: str, schema: str = "public") -> list:
+    """Return indexes left INVALID by an interrupted CONCURRENTLY build.
+
+    A failed `CREATE INDEX CONCURRENTLY` leaves an index behind that is never used by the
+    planner but is still maintained on write, and `IF NOT EXISTS` considers it present --
+    so the next run will not repair it. Surfacing the name is enough to act on.
+    """
+    cursor.execute(
+        """
+        SELECT i.relname
+        FROM pg_index x
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_class t ON t.oid = x.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE NOT x.indisvalid AND n.nspname = %s AND t.relname = %s
+        """,
+        (schema, collection),
+    )
+    return [row[0] for row in cursor.fetchall()]
+
+
+def apply_table_config(collection: str, table_config: dict, vector_secret_name: str) -> dict:
+    """Run the table_config statements against the features database."""
+    import psycopg2
+
+    from veda_data_pipeline.utils.vector_ingest.handler import get_secret
+
+    statements = build_statements(collection, table_config)
+    if not statements:
+        print("No table_config provided, skipping table configuration")
+        return {"status": "skipped", "statements": []}
+
+    secrets = get_secret(vector_secret_name)
+    conn = psycopg2.connect(
+        host=secrets["host"],
+        dbname=secrets["dbname"],
+        user=secrets["username"],
+        password=secrets["password"],
+    )
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    conn.autocommit = True
+
+    try:
+        with conn.cursor() as cursor:
+            for statement in statements:
+                print(f"Running: {statement}")
+                cursor.execute(statement)
+
+            invalid = find_invalid_indexes(
+                cursor, collection, table_config.get("schema", "public")
+            )
+            if invalid:
+                print(
+                    f"WARNING: invalid indexes on {collection} (likely an interrupted "
+                    f"CONCURRENTLY build); drop and recreate them: {invalid}"
+                )
+    finally:
+        conn.close()
+
+    return {"status": "success", "statements": statements}

--- a/dags/veda_data_pipeline/veda_vector_pipeline.py
+++ b/dags/veda_data_pipeline/veda_vector_pipeline.py
@@ -37,6 +37,35 @@ This DAG is supposed to be triggered by `veda_discover`. But you still can trigg
 
 }
 ```
+
+#### Table configuration
+`table_config` applies index and statistics DDL **once, after every discovered file has
+been ingested**. Omit the key entirely to skip it.
+
+```json
+{
+    "table_config": {
+        "schema": "public",
+        "indexes": [
+            {"columns": ["datetime"], "method": "btree", "concurrently": true}
+        ],
+        "analyze": true
+    }
+}
+```
+
+- Requires an explicit `collection`; with a per-file `id_template` there is no single
+  table to configure, and the step is skipped.
+- Indexes are built after load on purpose -- one bulk sort rather than per-row
+  maintenance during ingest.
+- `concurrently` defaults to true so the build does not take an `ACCESS EXCLUSIVE` lock
+  on a table the Features API is serving.
+- `-overwrite` drops and recreates the table, so any index is destroyed on each ingest
+  and rebuilt by this step.
+- **Backfilling across several DAG runs:** omit `table_config` from the intermediate runs
+  and set it only on the last, otherwise the index exists while later chunks are still
+  loading -- which is exactly what the post-ingest ordering avoids.
+
 - [Supports linking to external content](https://github.com/NASA-IMPACT/veda-data-pipelines)
 """
 
@@ -54,6 +83,15 @@ template_dag_run_conf = {
     "target_projection": "<crs>",
     "extra_flags": "<args>",
     "payload": "<s3_uri_event_payload>",
+    "table_config": Param(
+        None,
+        type=["null", "object"],
+        description=(
+            "Optional post-ingest table configuration, applied once after every file has "
+            "been ingested. Omit it entirely to skip. Example: "
+            '{"indexes": [{"columns": ["datetime"]}], "analyze": true}'
+        ),
+    ),
     "invalidate_cloudfront": Param(True, type="boolean")
 }
 dag_args = {
@@ -72,6 +110,35 @@ def ingest_vector_task(payload):
     vector_secret_name = Variable.get("VECTOR_SECRET_NAME")
     return handler(payload_src=payload, vector_secret_name=vector_secret_name,
                    assume_role_arn=read_role_arn)
+
+
+@task
+def configure_table(dag_run=None):
+    """Apply post-ingest table configuration once every mapped ingest task has finished.
+
+    Placed downstream of `ingest_vector_task.expand(...)` on purpose: Airflow runs a plain
+    task after *all* mapped instances complete, so indexes are built once on the finished
+    table rather than once per chunk. See utils/vector_ingest/table_config.py.
+    """
+    from veda_data_pipeline.utils.vector_ingest.table_config import apply_table_config
+
+    conf = dag_run.conf
+    table_config = conf.get("table_config")
+    if not table_config:
+        logging.info("No table_config provided, skipping table configuration")
+        return {"status": "skipped"}
+
+    collection = conf.get("collection")
+    if not collection:
+        # Without an explicit collection the ingest names a table per file from
+        # id_template, so there is no single table to configure.
+        logging.warning(
+            "table_config requires an explicit `collection`; skipping table configuration"
+        )
+        return {"status": "skipped"}
+
+    vector_secret_name = Variable.get("VECTOR_SECRET_NAME")
+    return apply_table_config(collection, table_config, vector_secret_name)
 
 
 @task
@@ -118,7 +185,7 @@ def get_ingest_vector_dag(id: str, event: dict):
         end = EmptyOperator(task_id="End", trigger_rule=TriggerRule.ONE_SUCCESS, dag=dag)
         discover = start >> discover_from_s3_task(event=event)
         get_files = get_files_task(payload=discover)
-        ingest_vector_task.expand(payload=get_files) >> invalidate_cloudfront() >> end
+        ingest_vector_task.expand(payload=get_files) >> configure_table() >> invalidate_cloudfront() >> end
 
         return dag
 

--- a/tests/test_table_config.py
+++ b/tests/test_table_config.py
@@ -1,0 +1,147 @@
+import pytest
+
+from veda_data_pipeline.utils.vector_ingest.table_config import (
+    ALLOWED_INDEX_METHODS,
+    MAX_IDENTIFIER_LENGTH,
+    InvalidTableConfig,
+    build_statements,
+    index_name,
+)
+
+
+def test_no_config_produces_no_statements():
+    """Omitting table_config is how a backfill's intermediate runs skip indexing."""
+    assert build_statements("hms_smoke", None) == []
+    assert build_statements("hms_smoke", {}) == []
+
+
+def test_single_index_and_analyze():
+    statements = build_statements(
+        "hms_smoke", {"indexes": [{"columns": ["datetime"]}]}
+    )
+    assert statements == [
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_hms_smoke_datetime" '
+        'ON "public"."hms_smoke" USING btree ("datetime")',
+        'ANALYZE "public"."hms_smoke"',
+    ]
+
+
+def test_concurrently_is_the_default():
+    """A blocking build on a table the Features API serves is a visible outage."""
+    (create, _) = build_statements("t", {"indexes": [{"columns": ["a"]}]})
+    assert "CONCURRENTLY" in create
+
+
+def test_concurrently_can_be_disabled():
+    (create, _) = build_statements(
+        "t", {"indexes": [{"columns": ["a"], "concurrently": False}]}
+    )
+    assert "CONCURRENTLY" not in create
+
+
+def test_if_not_exists_so_reruns_are_no_ops():
+    (create, _) = build_statements("t", {"indexes": [{"columns": ["a"]}]})
+    assert "IF NOT EXISTS" in create
+
+
+def test_multi_column_index():
+    (create, _) = build_statements(
+        "t", {"indexes": [{"columns": ["datetime", "density_rank"]}]}
+    )
+    assert '("datetime", "density_rank")' in create
+    assert '"idx_t_datetime_density_rank"' in create
+
+
+def test_schema_defaults_to_public_and_is_honoured():
+    (create, _) = build_statements(
+        "t", {"schema": "vector", "indexes": [{"columns": ["a"]}]}
+    )
+    assert 'ON "vector"."t"' in create
+
+
+def test_analyze_can_be_disabled():
+    statements = build_statements(
+        "t", {"indexes": [{"columns": ["a"]}], "analyze": False}
+    )
+    assert len(statements) == 1
+    assert "ANALYZE" not in statements[0]
+
+
+def test_analyze_only_config_is_valid():
+    assert build_statements("t", {"analyze": True}) == ['ANALYZE "public"."t"']
+
+
+def test_explicit_index_name_is_used():
+    (create, _) = build_statements(
+        "t", {"indexes": [{"columns": ["a"], "name": "my_index"}]}
+    )
+    assert '"my_index"' in create
+
+
+@pytest.mark.parametrize("method", sorted(ALLOWED_INDEX_METHODS))
+def test_allowed_methods(method):
+    (create, _) = build_statements(
+        "t", {"indexes": [{"columns": ["geom"], "method": method}]}
+    )
+    assert f"USING {method} " in create
+
+
+def test_unsupported_method_is_rejected():
+    """`method` reaches SQL as a bare keyword, so it must be allowlisted."""
+    with pytest.raises(InvalidTableConfig, match="unsupported index method"):
+        build_statements("t", {"indexes": [{"columns": ["a"], "method": "btree; DROP TABLE x"}]})
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ['a"; DROP TABLE users; --', "a b", "a-b", "1abc", "", "a;b", "a)"],
+)
+def test_malicious_or_odd_identifiers_are_rejected(bad):
+    with pytest.raises(InvalidTableConfig):
+        build_statements("t", {"indexes": [{"columns": [bad]}]})
+
+
+def test_bad_collection_name_is_rejected():
+    with pytest.raises(InvalidTableConfig, match="invalid collection"):
+        build_statements('t"; DROP TABLE x; --', {"indexes": [{"columns": ["a"]}]})
+
+
+def test_bad_schema_is_rejected():
+    with pytest.raises(InvalidTableConfig, match="invalid schema"):
+        build_statements("t", {"schema": "public; DROP TABLE x", "indexes": []})
+
+
+def test_index_without_columns_is_rejected():
+    with pytest.raises(InvalidTableConfig, match="no columns"):
+        build_statements("t", {"indexes": [{"method": "btree"}]})
+
+
+def test_index_name_is_truncated_to_postgres_limit():
+    """An over-long name would be truncated by Postgres, so IF NOT EXISTS would miss it
+    and the index would be rebuilt on every run."""
+    name = index_name("t" * 50, ["c" * 50], "btree")
+    assert len(name) == MAX_IDENTIFIER_LENGTH
+
+
+def test_index_name_is_deterministic():
+    assert index_name("t", ["a", "b"], "btree") == index_name("t", ["a", "b"], "btree")
+
+
+def test_non_btree_method_is_part_of_the_name():
+    """Two indexes on the same column with different methods must not collide."""
+    assert index_name("t", ["geom"], "btree") != index_name("t", ["geom"], "gist")
+
+
+def test_several_indexes_are_all_emitted():
+    statements = build_statements(
+        "t",
+        {
+            "indexes": [
+                {"columns": ["datetime"]},
+                {"columns": ["geom"], "method": "gist"},
+            ]
+        },
+    )
+    assert len(statements) == 3  # two creates plus ANALYZE
+    assert "USING btree" in statements[0]
+    assert "USING gist" in statements[1]

--- a/tests/test_table_config_integration.py
+++ b/tests/test_table_config_integration.py
@@ -1,0 +1,160 @@
+"""Integration tests for table_config against a real Postgres.
+
+Skipped unless TEST_DATABASE_URL is set, so the default test run stays offline.
+
+    docker run -d --name veda-test-pg -p 55432:5432 \
+        -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres \
+        postgis/postgis:16-3.4
+
+    TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:55432/postgres \
+        pytest tests/test_table_config_integration.py -v
+
+These cover what the unit tests cannot: that the generated DDL is valid Postgres, that
+CREATE INDEX CONCURRENTLY works under the autocommit handling, and that the invalid-index
+query returns what it claims to.
+"""
+
+import os
+
+import pytest
+
+from veda_data_pipeline.utils.vector_ingest.table_config import (
+    find_invalid_indexes,
+    run_statements,
+)
+
+DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not DATABASE_URL, reason="set TEST_DATABASE_URL to run integration tests"
+)
+
+TABLE = "hms_smoke_test"
+
+
+@pytest.fixture
+def conn():
+    import psycopg2
+
+    connection = psycopg2.connect(DATABASE_URL)
+    connection.autocommit = True
+    with connection.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS public.{TABLE}")
+        cur.execute(
+            f"""
+            CREATE TABLE public.{TABLE} (
+                fid           serial PRIMARY KEY,
+                datetime      timestamptz,
+                density       text,
+                density_rank  integer,
+                geom          geometry(MultiPolygon, 4326)
+            )
+            """
+        )
+        cur.execute(
+            f"INSERT INTO public.{TABLE} (datetime, density, density_rank) "
+            f"SELECT now(), 'Light', 1 FROM generate_series(1, 500)"
+        )
+    yield connection
+    with connection.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS public.{TABLE}")
+    connection.close()
+
+
+def indexes_on(conn, table=TABLE):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexname FROM pg_indexes WHERE schemaname='public' AND tablename=%s",
+            (table,),
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+def test_creates_the_index_concurrently(conn):
+    """The default path: CONCURRENTLY, which needs autocommit to work at all."""
+    result = run_statements(conn, TABLE, {"indexes": [{"columns": ["datetime"]}]})
+    assert result["status"] == "success"
+    assert f"idx_{TABLE}_datetime" in indexes_on(conn)
+
+
+def test_rerun_is_a_no_op(conn):
+    """IF NOT EXISTS plus deterministic naming means re-ingest does not rebuild."""
+    config = {"indexes": [{"columns": ["datetime"]}]}
+    run_statements(conn, TABLE, config)
+    before = indexes_on(conn)
+    run_statements(conn, TABLE, config)
+    assert indexes_on(conn) == before
+
+
+def test_non_concurrent_index(conn):
+    run_statements(
+        conn, TABLE, {"indexes": [{"columns": ["density"], "concurrently": False}]}
+    )
+    assert f"idx_{TABLE}_density" in indexes_on(conn)
+
+
+def test_multi_column_index(conn):
+    run_statements(conn, TABLE, {"indexes": [{"columns": ["datetime", "density_rank"]}]})
+    assert f"idx_{TABLE}_datetime_density_rank" in indexes_on(conn)
+
+
+def test_gist_index_on_geometry(conn):
+    run_statements(conn, TABLE, {"indexes": [{"columns": ["geom"], "method": "gist"}]})
+    assert f"idx_{TABLE}_geom_gist" in indexes_on(conn)
+
+
+def test_analyze_populates_planner_statistics(conn):
+    """Without stats the planner will not use the index that was just built."""
+    with conn.cursor() as cur:
+        cur.execute(f"DELETE FROM pg_statistic WHERE starelid = 'public.{TABLE}'::regclass")
+    run_statements(conn, TABLE, {"indexes": [{"columns": ["datetime"]}], "analyze": True})
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM pg_stats WHERE schemaname='public' AND tablename=%s",
+            (TABLE,),
+        )
+        assert cur.fetchone()[0] > 0
+
+
+def test_several_indexes_in_one_config(conn):
+    run_statements(
+        conn,
+        TABLE,
+        {
+            "indexes": [
+                {"columns": ["datetime"]},
+                {"columns": ["density_rank"]},
+                {"columns": ["geom"], "method": "gist"},
+            ]
+        },
+    )
+    created = indexes_on(conn)
+    assert {
+        f"idx_{TABLE}_datetime",
+        f"idx_{TABLE}_density_rank",
+        f"idx_{TABLE}_geom_gist",
+    } <= created
+
+
+def test_no_invalid_indexes_after_a_clean_run(conn):
+    run_statements(conn, TABLE, {"indexes": [{"columns": ["datetime"]}]})
+    assert find_invalid_indexes(conn.cursor(), TABLE) == []
+
+
+def test_invalid_index_is_detected(conn):
+    """An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT EXISTS
+    considers present, so it would never be repaired. Simulated by marking it invalid."""
+    run_statements(conn, TABLE, {"indexes": [{"columns": ["datetime"]}]})
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE pg_index SET indisvalid = false "
+            f"WHERE indexrelid = 'public.idx_{TABLE}_datetime'::regclass"
+        )
+    assert find_invalid_indexes(conn.cursor(), TABLE) == [f"idx_{TABLE}_datetime"]
+
+
+def test_empty_config_touches_nothing(conn):
+    before = indexes_on(conn)
+    assert run_statements(conn, TABLE, None)["status"] == "skipped"
+    assert run_statements(conn, TABLE, {})["status"] == "skipped"
+    assert indexes_on(conn) == before


### PR DESCRIPTION
Adds an optional `table_config` block to `veda_ingest_vector` that applies index and statistics DDL to a vector collection after ingest.

## Why

`ogr2ogr` creates the GiST index on the geometry column and has no option for an index on any other column, so a collection with a datetime column has no index on it. Queries like `/items?datetime=...` with no bounding box fall back to a sequential scan. The only automatic index step today is `alter_datetime_add_indexes_eis()` (`handler.py:314`), hardcoded to fire only when the prefix starts with `EIS/` — this generalizes that.

Compounding it, `-overwrite` drops and recreates the table, so any index added by hand is destroyed on every re-ingest.

## Usage

```json
{
  "collection": "hms_smoke",
  "table_config": {
    "schema": "public",
    "indexes": [
      {"columns": ["datetime"], "method": "btree", "concurrently": true}
    ],
    "analyze": true
  }
}
```

Omit the key entirely to skip the step. Existing configs are unaffected.

## Why it runs after ingest

Building an index in one bulk sort is cheaper than maintaining it row by row while data loads. The new `configure_table` task sits downstream of `ingest_vector_task.expand(...)`, so Airflow runs it **once after every mapped instance completes** rather than once per file:

```
Start → discover → get_files → ingest_vector_task (mapped) → configure_table → invalidate_cloudfront → End
```

One consequence worth knowing, documented in the DAG doc and the pipeline README: if a backfill is split across **several DAG runs**, omit `table_config` from the intermediate runs and set it only on the last. Otherwise the index is created after the first run and every later chunk loads into an indexed table — the situation this ordering exists to avoid. Within a single run it is handled automatically.

## Design notes

- **`concurrently` defaults to true.** A blocking `CREATE INDEX` takes an `ACCESS EXCLUSIVE` lock; on a large table the Features API is serving that is a visible outage, not just a slow ingest. This requires autocommit, since `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block.
- **Constrained schema rather than a SQL escape hatch.** These configs come from `s3://$EVENT_BUCKET/collections/*.json` and from manual triggers, so arbitrary SQL in them is hard to review. Statements are composed with `psycopg2.sql`: every schema, table, column, index and access-method name reaches Postgres as a driver-quoted identifier, and no config value is formatted into SQL text. Identifiers are also validated against a strict pattern so a malformed config fails before any statement runs. PEP 750 template strings would need Python 3.14 and psycopg 3; the project is pinned to Python 3.12 and psycopg2.
- **Deterministic index names, truncated to 63 characters.** Postgres truncates silently, so an over-long name would not match what `IF NOT EXISTS` looks for and the index would be rebuilt every run.
- **Invalid indexes are reported.** An interrupted `CONCURRENTLY` build leaves an INVALID index that `IF NOT EXISTS` treats as present, so it would never self-repair.
- **Requires an explicit `collection`.** With a per-file `id_template` there is no single table to configure, and the step is skipped with a warning.

## Testing

`build_statements()` is separated from execution so SQL generation is testable without a database, and `run_statements(conn, ...)` takes an open connection so the execution path can be pointed at any Postgres without AWS.

- **33 unit tests** — statement structure (including that no config value appears in the SQL text), identifier rejection (including `'a"; DROP TABLE users; --'`), method allowlisting, naming and truncation.
- **12 integration tests**, skipped unless `TEST_DATABASE_URL` is set so the default run stays offline. These cover what unit tests cannot: the exact rendered SQL, that the DDL is valid Postgres, that `CONCURRENTLY` works under the autocommit handling, that the task result is JSON-serializable for XCom, that a re-run is a genuine no-op, that `ANALYZE` populates `pg_stats`, and that the `pg_index` query finds an index left INVALID.

```bash
docker run -d --name veda-test-pg -p 55432:5432 \
    -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres \
    postgis/postgis:16-3.4

TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:55432/postgres \
    pytest tests/test_table_config_integration.py
```

All 12 pass against PostGIS 16. Also rehearsed against real data — 932 HMS smoke features with the datetime index dropped to simulate the post-ingest state, where `ogr2ogr` has created only the geometry GiST — and confirmed the planner uses the result rather than only that the DDL ran:

```
Index Scan using idx_hms_smoke_datetime on hms_smoke
```

Full suite: 100 passed, 12 skipped. The 3 failures on this branch are pre-existing `ModuleNotFoundError: No module named 'stactools'` and reproduce identically on a clean `dev` tree.

## Deliberately not included

- **`mode: replace|append`.** Table lifecycle is currently a side effect of whether someone put `-overwrite` or `-append` in `extra_flags`. Promoting it to an explicit field would make the destructive behaviour visible and let the DAG know whether indexes need rebuilding — but it changes behaviour for every existing collection and deserves its own review.
- **The `-append` fan-out race.** The pipeline README recommends `-append` to merge multiple files into one collection, but mapped ingest tasks run concurrently and race on table creation. Fixing it properly needs the table pre-created, which needs schema knowledge the DAG does not have generically.

Draft while the above two are decided.

